### PR TITLE
slay muted users after voting phase

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -3073,6 +3073,9 @@ function Mafia(mafiachan) {
     this.onMute = function(src) {
         if (this.state != "day")
             this.slayUser(Config.capsbot, sys.name(src));
+		else
+			sys.delayedCall(function() { mafia.slayUser(Config.capsbot, sys.name(src)); }, mafia.ticks+1);
+			// slays user after the day phase is over
     };
 
     this.onMban = function(src) {


### PR DESCRIPTION
While playing mafia I noticed that users muted during the day would just hang around kind of helpless unless there was a mod to mute/slay them.
This should slay someone after the voting phase is over.
The only problem is that if the voting time is extended by late voters, the added time isn't taken into account :x
