### PR TITLE
Channel Hijacking

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -2170,8 +2170,8 @@ userCommand: function(src, command, commandData, tar) {
 
     if (command == "register") {
 		var creator = SESSION.channels(channel).creator;
-		if ((sys.id(creator) == undefined || creator == sys.name(src).toLowerCase()) && 
-			!SESSION.channels(channel).isRegistered() /* This channel is already registered! will display*/) {
+		if ((sys.id(creator) == undefined || creator == sys.name(src).toLowerCase()) || 
+			SESSION.channels(channel).isRegistered() /* This channel is already registered! will display*/) {
 			if (SESSION.channels(channel).register(sys.name(src))) {
 				channelbot.sendChanMessage(src, "You registered this channel successfully. Take a look of /commands channel");
 			} else {


### PR DESCRIPTION
This makes channel hijacking very hard to do (/changecreator is there for existing channels, POChannel.registered because it doesn't add the creator into masters - check cauth for why). Creators have master permission but can't use channel commands before the channel is registered. (Indent was done with one tab character)
