### PR TITLE
clearPoison for converted roles

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -1434,6 +1434,9 @@ this.possibleThemes[themeName] = 0;
                 player.poisonCount = condition.poison.count || 2;
                 player.poisonDeadMessage = condition.poison.poisonDeadMessage;
             }
+			if ("clearPoison" in condition) {
+				player.poisoned = undefined;
+			}
         }
     };
     this.testWin = function () {


### PR DESCRIPTION
When someone is poisoned, it keeps the poison status even after converted to another role.
To prevent this, setting

"initialCondition": {
"clearpoison": true
}

or any other value intead of true clears the poison status.
