### PR TITLE
Random votes and converts

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -2097,14 +2097,17 @@ function Mafia(mafiachan) {
                             if ("canConvert" in Action && Action.canConvert != "*" && Action.canConvert.indexOf(target.role.role) == -1) {
                                 mafia.sendPlayer(player.name, "±Game: Your target (" + target.name + ") couldn't be converted!");
                             } else {
-                                var oldRole = target.role;
-                                var newRole = undefined;
+                                var oldRole = target.role, newRole;
                                 if (typeof Action.newRole == "object") {
-                                    var possibleRoles = shuffle(Object.keys(Action.newRole));
-                                    for (var nr in possibleRoles) {
-                                        if (Action.newRole[possibleRoles[nr]].indexOf(oldRole.role) != -1) {
-                                            newRole = possibleRoles[nr];
-                                            break;
+                                    if ("random" in Action.newRole && !Array.isArray(Action.newRole.random) && typeof Action.newRole.random === "object" && Action.newRole.random !== null) {
+                                        newRole = randomSample(Action.newRole.random);
+                                    } else {
+                                        var possibleRoles = shuffle(Object.keys(Action.newRole));
+                                        for (var nr in possibleRoles) {
+                                            if (Action.newRole[possibleRoles[nr]].indexOf(oldRole.role) != -1) {
+                                                newRole = possibleRoles[nr];
+                                                break;
+                                            }
                                         }
                                     }
                                 } else {


### PR DESCRIPTION
vote(shield) can now be randomized by making it an array and giving it 2 values. 1st is inclusive, 2nd is exclusive.

Also added a newRole.random for /convert. It carefully checks if the property is an Object, and not an Array, so it shouldn't break anything.
