### PR TITLE
Small fix for Inspect

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -1930,7 +1930,7 @@ function Mafia(mafiachan) {
                             } else {
                                 target = mafia.players[target];
     
-                                var targetMode;
+                                var targetMode = undefined;
                                 var revenge = false;
                                 var revengetext = "±Game: You were killed during the night!";
                                 var poisonrevenge, poisonDeadMessage;
@@ -2106,7 +2106,7 @@ function Mafia(mafiachan) {
                             }
                             else if (command == "inspect") {
                                 var Sight = Action.Sight;
-                                var targetMode = targetMode || {};
+                                targetMode = targetMode || {};
                                 if (targetMode.revealSide !== undefined || Sight === "Team") {
                                     mafia.sendPlayer(player.name, "±Info: " + target.name + " is sided with the " + mafia.theme.trside(target.role.side) + "!!");
                                 } else if (typeof Sight == "object") {


### PR DESCRIPTION
Clumsy fix, but works (prevents an inspector with lower priority from inspecting someone as the wrong role if a faster inspector inspected a miller).
