### PR TITLE
Mafia: Night and Standby target as Array | role.deathmsg

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -1320,7 +1320,9 @@ function Mafia(mafiachan) {
         }
     };
     this.kill = function (player) {
-        if (this.theme.killmsg) {
+        if (player.role.deathmsg) {
+            sendChanAll(player.role.deathmsg.replace(/~Player~/g, player.name).replace(/~Role~/g, player.role.translation), mafiachan);
+        } else if (this.theme.killmsg) {
             sendChanAll(this.theme.killmsg.replace(/~Player~/g, player.name).replace(/~Role~/g, player.role.translation), mafiachan);
         } else {
             sendChanAll("±Kill: " + player.name + " (" + player.role.translation + ") died!", mafiachan);


### PR DESCRIPTION
Also makes it optional.

deathmsg is displayed when the player dies. Has priority over global killmsg
