### PR TITLE
Random Role on Spawn List, /copy and /curse

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -1311,6 +1311,29 @@ function Mafia(mafiachan) {
                     }
                 }
             }
+            if ("curseRoles" in onDeath) {
+                targetRoles = onDeath.curseRoles;
+                for (r in targetRoles) {
+                    var cursedRole = onDeath.curseRoles[r], count = onDeath.curseCount;
+                    targetPlayers = this.getPlayersForRole(r);
+                    affected = [];
+                    for (k = 0; k < targetPlayers.length; ++k) {
+                        if (this.players[targetPlayers[k]] != player) {
+                            affected.push(targetPlayers[k]);
+                            target = this.players[targetPlayers[k]];
+                            target.cursedRole = cursedRole;
+                            target.cursed = 1;
+                            target.curseCount = count || 2;
+                            target.curseConvertMessage = onDeath.curseConvertMessage;
+                        }
+                    }
+                    if (affected.length > 0) {
+                        actionMessage = onDeath.cursemsg ? onDeath.cursemsg : "±Game: Because ~Self~ died, the ~Old~ got cursed and will become a ~New~ soon!";
+                        sendChanAll(actionMessage.replace(/~Self~/g, player.name).replace(/~Target~/g, readable(affected, "and")).replace(/~Old~/g, mafia.theme.trrole(r)).replace(/~New~/g, mafia.theme.trrole(cursedRole)).replace(/~Count~/g, count || 2), mafiachan);
+                        needSeparator = true;
+                    }
+                }
+            }
             if ("exposeRoles" in onDeath) {
                 targetRoles = onDeath.exposeRoles;
                 for (r = 0; r < targetRoles.length; ++r) {
@@ -1550,6 +1573,15 @@ function Mafia(mafiachan) {
             if ("clearPoison" in condition) {
                 player.poisoned = undefined;
             }
+            if ("curse" in condition) {
+                player.cursed = 1;
+                player.curseCount = condition.curse.curseCount || 2;
+                player.cursedRole = condition.curse.cursedRole;
+                player.curseConvertMessage = condition.curse.curseConvertMessage;
+            }
+            if ("clearCurse" in condition) {
+                player.cursed = undefined;
+            }
         }
     };
     this.testWin = function () {
@@ -1757,6 +1789,12 @@ function Mafia(mafiachan) {
                         initPlayer.poisonCount = condition.poison.count || 2;
                         initPlayer.poisonDeadMessage = condition.poison.poisonDeadMessage;
                     }
+                    if ("curse" in condition) {
+                        initPlayer.cursed = 1;
+                        initPlayer.curseCount = condition.curse.curseCount || 2;
+                        initPlayer.cursedRole = condition.curse.cursedRole;
+                        initPlayer.curseConvertMessage = condition.curse.curseConvertMessage;
+                    }
                 }
                 if (typeof mafia.theme.roles[playerRole].side == "object") {
                     if ("random" in mafia.theme.roles[playerRole].side) {
@@ -1934,7 +1972,7 @@ function Mafia(mafiachan) {
                         for (var c in commandList) {
                             target = targets[t];
                             command = commandList[c];
-                            if (["kill", "protect", "inspect", "distract", "poison", "safeguard", "stalk", "convert"].indexOf(command) == -1) {
+                            if (["kill", "protect", "inspect", "distract", "poison", "safeguard", "stalk", "convert", "copy", "curse"].indexOf(command) == -1) {
                                 continue;
                             }
                             if (!mafia.isInGame(target)) {
@@ -1950,7 +1988,7 @@ function Mafia(mafiachan) {
                                 var poisonrevengetext = "±Game: Your target poisoned you!";
     
                                 // Action blocked by Protect or Safeguard
-                                if ((target.guarded && command == "kill") || (target.safeguarded && ["distract", "inspect", "stalk", "poison", "convert", "copy"].indexOf(command) !== -1)) {
+                                if ((target.guarded && command == "kill") || (target.safeguarded && ["distract", "inspect", "stalk", "poison", "convert", "copy", "curse"].indexOf(command) !== -1)) {
                                     mafia.sendPlayer(player.name, "±Game: Your target (" + target.name + ") was " + (command == "kill" ? "protected" : "guarded") + "!");
                                     // Action can be countered even if target is protected/guarded
                                     if (command in target.role.actions) {
@@ -2247,6 +2285,39 @@ function Mafia(mafiachan) {
                                     }
                                 }
                             }
+                            else if(command == "curse") {
+                                if ("canCurse" in Action && Action.canCurse != "*" && Action.canCurse.indexOf(target.role.role) == -1) {
+                                    mafia.sendPlayer(player.name, "±Game: Your target (" + target.name + ") couldn't be cursed!");
+                                } else {
+                                    var oldRole = target.role, cursedRole = undefined;
+                                    if (typeof Action.cursedRole == "object") {
+                                        if ("random" in Action.cursedRole && !Array.isArray(Action.cursedRole.random) && typeof Action.cursedRole.random === "object" && Action.cursedRole.random !== null) {
+                                            cursedRole = randomSample(Action.cursedRole.random);
+                                        } else {
+                                            var possibleRoles = shuffle(Object.keys(Action.cursedRole));
+                                            for (var nr in possibleRoles) {
+                                                if (Action.cursedRole[possibleRoles[nr]].indexOf(oldRole.role) != -1) {
+                                                    cursedRole = possibleRoles[nr];
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        cursedRole = Action.cursedRole;
+                                    }
+                                    if (cursedRole === undefined) {
+                                        mafia.sendPlayer(player.name, "±Game: Your target (" + target.name + ") couldn't be cursed!");
+                                    } else {
+                                        mafia.sendPlayer(player.name, "±Game: Your target (" + target.name + ") was cursed!");
+                                        target.cursed = 1;
+                                        target.curseCount = Action.curseCount || 2;
+                                        target.cursedRole = cursedRole;
+                                        if (!Action.silent) {
+                                            target.curseConvertMessage = Action.curseConvertMessage || "~Target~'s has been converted into a ~New~!";
+                                        }
+                                    }
+                                }
+                            }
     
                             //Post-Action effects here
                             if (revenge) {
@@ -2290,6 +2361,22 @@ function Mafia(mafiachan) {
                         mafia.sendPlayer(player.name, "±Game: " + (player.poisonDeadMessage ? player.poisonDeadMessage : "You died because of Poison!"));
                         mafia.kill(player);
                         nightkill = true; // kinda night kill
+                    }
+                }
+                var curseCount = player.curseCount;
+                if (curseCount !== undefined) {
+                    if (player.cursed < curseCount) {
+                        mafia.sendPlayer(player.name, "±Game: You will convert in " + (player.curseCount - player.cursed) + " days.");
+                        player.cursed++;
+                    } else if (player.cursed >= curseCount) {
+                        if (player.curseConvertMessage) {
+                            sendChanAll("±Game: " + player.curseConvertMessage.replace(/~Target~/g, player.name).replace(/~Player~/g, player.name).replace(/~Old~/g, player.role.translation).replace(/~New~/g, mafia.theme.roles[player.cursedRole].translation), mafiachan);
+                            player.curseConvertMessage = undefined;
+                        }
+                        mafia.sendPlayer(player.name, "±Game: Your curse took effect and you changed roles!");
+                        mafia.setPlayerRole (player, player.cursedRole);
+                        mafia.showOwnRole(sys.id(player.name));
+                        player.curseCount = undefined;
                     }
                 }
             }


### PR DESCRIPTION
-Can set a { "role1": 0.4, "role2": 0.6 } instead of a role on respawn lists for a random role.
-Copy is a Convert that changes the user according to the target (AKA Ditto).
-Curse is a Timed Convert (similar to poison). Coded by BeastCharizard.
-And a minor change in Inspect.revealAs: "*" due to random role thing.
