### PR TITLE
Mafia: Fix for winningSides

### DIFF
--- a/mafia.js
+++ b/mafia.js
@@ -1610,7 +1610,7 @@ function Mafia(mafiachan) {
                         } else if (winSide == 'village') {
                                 // if winSide = villy all people must be good people
                             continue outer;
-                        } else if (mafia.players[x].role.side == 'village') {
+                        } else if (mafia.players[x].role.side == 'village' && (!mafia.players[p].role.hasOwnProperty("winningSides") || (mafia.players[p].role.winningSides != "*" && mafia.players[p].role.winningSides.indexOf("village") == -1))) {
                             goodPeople.push(x);
                         } else {
                             // some other baddie team alive


### PR DESCRIPTION
This should prevent Conspirator winning alone in a Conspirator vs Villager situation where the Conspirator joined the game before the villager.
