### PR TITLE
Mafia: Fix for winning players list

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -1663,6 +1663,8 @@ function Mafia(mafiachan) {
                     }
                 }
                 winSide = mafia.players[p].role.side;
+                players = [];
+                goodPeople = [];
                 if (winByDeadRoles) {
                     players = mafia.getPlayersForTeam(winSide);
                     for (x in mafia.players) {


### PR DESCRIPTION
Error it causes at http://pokemon-online.eu/forums/showthread.php?18159-messed-up-default-game
The Winning Players array need to be reset each time a different player is being checked for win conditions.
