### PR TITLE
Mafia: Fix for readlog and copy

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -867,6 +867,9 @@ function Mafia(mafiachan) {
         return noPlayer;
     };
     this.saveStalkLog = function () {
+        if (this.state == "standby") {
+            this.compilePhaseStalk("STANDBY " + mafia.time.days);
+        }
         if (this.state !== "blank" && this.state !== "voting" && currentStalk.length > 0) {
             var lastLog = currentStalk.join("::**::");
             stalkLogs.unshift(lastLog);


### PR DESCRIPTION
Fix: Readlog not saving actions used in the last phase when the game ends with a daykill.
Fix: copymsg showing Target's role instead of Player.
Added: copy.copyAs as a role string.
