### PR TITLE
Odd tour conditions for Metronome

### DIFF
--- a/scripts/tours.js
+++ b/scripts/tours.js
@@ -4039,21 +4039,7 @@ function toursortbracket(size, key) {
             templist.push([pl, pr1, pr2, pr3]);
         }
         var sortalgorithim = function(a,b) {
-            if (ttype == "Metronome") {
-                if (a[1] == -1 && b[1] == -1) {
-                    return a[3]-b[3];
-                }
-                else if (a[1] == -1) {
-                    return 1;
-                }
-                else if (b[1] == -1) {
-                    return -1;
-                }
-                else {
-                    return 0.5-Math.random();
-                }
-            }
-            else if (a[1] !== b[1]) {
+            if (a[1] !== b[1]) {
                 return b[1]-a[1];
             }
             else if (a[2] !== b[2]) {


### PR DESCRIPTION
There was a very peculiar case for the sorting function for tours.

var sortalgorithim = function(a,b) {
            /*if (ttype == "Metronome") {
                if (a[1] == -1 && b[1] == -1) {
                    return a[3]-b[3];
                }
                else if (a[1] == -1) {
                    return 1;
                }
                else if (b[1] == -1) {
                    return -1;
                }
                else {
                    return 0.5-Math.random();
                }
            }
            else */if (a[1] !== b[1]) {
                return b[1]-a[1];
            }
            else if (a[2] !== b[2]) {
                return b[2]-a[2];
            }
            else if (a[3] !== b[3]) {
                return a[3]-b[3];
            }
            else {
                return 0.5-Math.random();
            }
        }

The commented out section was removed.
