### PR TITLE
Adding cooldown for Default

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -1069,7 +1069,7 @@ function Mafia(mafiachan) {
                         sys.sendMessage(src, "±Game: Sorry, you have started a game " + (i + 1) + " games ago, let someone else have a chance!", mafiachan);
                         return;
                     }
-                    if (themeName !== "default" && what == themeName) {
+                    if (what == themeName) {
                         sys.sendMessage(src, "±Game: This theme was started " + (i + 1) + " games ago! No repeat!", mafiachan);
                         return;
                     }


### PR DESCRIPTION
Kills the channel's mood. Plus we have like 40 other themes you can start, no reason to have default be able to be started multiple times anymore. Maybe if it was actually balanced that would be another story.
