### PR TITLE
Ends game automatically if one is started during update

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -3914,7 +3914,7 @@ function Mafia(mafiachan) {
                 POglobal.plugins[index] = module;
                 module.source = source;
                 module.init();
-                this.endGame();
+                mafia.endGame();
                 sendChanAll("Update complete!", mafiachan);
             });
             sendChanAll("Updating mafia game...", mafiachan);


### PR DESCRIPTION
What happens without it:

(23:46:56) Updating mafia game...
(23:46:56) ***************************************************************************************
(23:46:56) ±Game: Fuzzy started a game!
(23:46:56) ±Game: Type /Join to enter the game!
(23:46:56) ***************************************************************************************
(23:46:56) ±Game: Consider adding a summary field to this theme that describes the setting of the game and points out the odd quirks of the theme!
(23:46:56) ±Game: Fuzzy joined the game!
(23:46:57) Update complete!

(On someone that wasn't already in game): (23:47:05) ±Game: You can't join now!
(23:47:15) ±CommandBot: The command unjoin doesn't exist

(23:47:44) ***************************************************************************************
(23:47:44) ±Game: Fuzzy started a game!
(23:47:44) ±Game: Type /Join to enter the game!
(23:47:44) ***************************************************************************************
