### PR TITLE
Mafia: /targetlog, Standby Recharge fix

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -2862,7 +2862,7 @@ function Mafia(mafiachan) {
                 }
                 if (p in mafia.dayRecharges) {
                     for (var r in mafia.dayRecharges[p]) {
-                        mafia.setRechargeFor(player, "standby", r, player.role.actions.standby[r].recharge);
+                        mafia.setRechargeFor(player, "standby", r, mafia.dayRecharges[p][r]);
                     }
                 }
             }
@@ -3775,7 +3775,7 @@ function Mafia(mafiachan) {
                                 if (!(player.name in this.dayRecharges)) {
                                     this.dayRecharges[player.name] = {};
                                 }
-                                this.dayRecharges[player.name][commandName] = 1;
+                                this.dayRecharges[player.name][commandName] = commandObject.recharge;
                             }
                             if (charges !== undefined) {
                                 mafia.removeCharge(player, "standby", commandName);
@@ -3890,7 +3890,7 @@ function Mafia(mafiachan) {
                                 if (!(player.name in this.dayRecharges)) {
                                     this.dayRecharges[player.name] = {};
                                 }
-                                this.dayRecharges[player.name][commandName] = 1;
+                                this.dayRecharges[player.name][commandName] = commandObject.recharge;
                             }
                             if (charges !== undefined) {
                                 mafia.removeCharge(player, "standby", commandName);
@@ -3979,7 +3979,7 @@ function Mafia(mafiachan) {
                     if (!(player.name in this.dayRecharges)) {
                         this.dayRecharges[player.name] = {};
                     }
-                    this.dayRecharges[player.name][commandName] = 1;
+                    this.dayRecharges[player.name][commandName] = commandObject.recharge;
                 }
                 if (charges !== undefined) {
                     mafia.removeCharge(player, "standby", commandName);


### PR DESCRIPTION
Fixing a rather rare error with standby recharge.

And adding /targetlog, because Fuzzy:
(21:09) RiceKirby: targetlog was really easy to code
(21:09) Fuzzy: i cant even make cereal and milk without starting a fire

Also adding a public message for when games end so people can make mafia games-related Client Scripts.
