### PR TITLE
Prevents smuted users from joining tours

### DIFF
--- a/scripts/tours.js
+++ b/scripts/tours.js
@@ -2573,6 +2573,11 @@ function tourCommand(src, command, commandData, channel) {
                 else {
                     tours.tour[key].numjoins[sys.ip(src)] = 1;
                 }
+                if (SESSION.users(src).smute.active) {
+                    var index = tours.tour[key].players.indexOf(src);
+                    tours.tour[key].players.splice(index, 1);
+                    tours.tour[key].cpt -= 1;
+                }
                 return true;
             }
             /* subbing */


### PR DESCRIPTION
Ripped from DQ during sign up phase.

(22:37:36) ±Dratini: Fuzzy2 was secretly muted by F​uzzy! [Channel: Tournaments](22:41:52) ±Typhlosion: Fuzzy force started the All tournament!
(22:41:56) ±Typhlosion: Fuzzy2 is player #1 to join the All tournament! 196 seconds remaining!
(22:41:56) Debug: USER TAKEN OUT (This wont display in the actual thing)
(22:44:51) ±Dratini: Fuzzy2 was secretly unmuted by F​uzzy!
(22:44:56) ±Typhlosion: Fuzzy2 is player #1 to join the All tournament! 16 seconds remaining!

Only problem is the numbering is undone, so if someone is watching closely, they could deduce something is up. I had no idea how to get that changed. I've tried moving it all around, tried with and without the .cpt -= 1, tried with += 1, etc. 
