### PR TITLE
Channel staff demotion, dq command changes for Trivia and Tours

### DIFF
--- a/scripts/hangman.js
+++ b/scripts/hangman.js
@@ -549,8 +549,8 @@ module.exports = function () {
         var superAdminHelp = [
             "*** Hangman Super Admin Commands ***",
             "/config: To change the answer delay time and other settings. Format /config parameter:value. Type /config by itself to see more help.",
-            "/hangmanadmin: To promote a new Hangman admin. Use /shangmanadmin for a silent promotion.",
-            "/hangmanadminoff: To demote a Hangman admin. Use /shangmanadminoff for a silent demotion."
+            "/hangmanadmin: To promote a new Hangman Admin. Use /shangmanadmin for a silent promotion.",
+            "/hangmanadminoff: To demote a Hangman Admin or a Hangman Super Admin. Use /shangmanadminoff for a silent demotion."
         ];
         var ownerHelp = [
             "*** Hangman Owner Commands ***",
@@ -748,7 +748,6 @@ module.exports = function () {
         shas = shas.sort();
         sys.sendMessage(src, "", channel);
         sys.sendMessage(src, "*** SUPER HANGMAN ADMINS ***", channel);
-        sys.sendMessage(src, "", channel);
         for (var i = 0; i < shas.length; i++) {
             var id = sys.id(shas[i]);
             if(!id) {
@@ -766,7 +765,6 @@ module.exports = function () {
         if (script.hasAuthElements(has)) {
             sys.sendMessage(src, "", channel);
             sys.sendMessage(src, "*** AUTH HANGMAN ADMINS ***", channel);
-            sys.sendMessage(src, "", channel);
             for (var i = 0; i < has.length; i++) {
                 if (sys.dbAuths().indexOf(has[i]) != -1) {
                     var id = sys.id(has[i]);
@@ -783,7 +781,6 @@ module.exports = function () {
         }
         sys.sendMessage(src, "", channel);
         sys.sendMessage(src, "*** HANGMAN ADMINS ***", channel);
-        sys.sendMessage(src, "", channel);
         for (var i = 0; i < has.length; i++) {
             var id = sys.id(has[i]);
             if(!id) {
@@ -829,16 +826,25 @@ module.exports = function () {
         if (commandData === undefined) {
             return;
         }
-        if (!script.hangmanAdmins.hash.hasOwnProperty(commandData.toLowerCase())) {
-            sys.sendMessage(src, "±Unown: " + commandData + " is not a Hangman Admin!", channel);
+        var isHA = script.hangmanAdmins.hash.hasOwnProperty(commandData.toLowerCase());
+        var isSHA = script.hangmanSuperAdmins.hash.hasOwnProperty(commandData.toLowerCase());
+        if (!isHA && !isSHA) {
+            sys.sendMessage(src, "±Unown: " + commandData + " is not a Hangman auth!", channel);
             return;
         }
+        if (isSHA && sys.auth(src) < 3) {
+            sys.sendMessage(src, "±Unown: You don't have enough auth!", channel);
+            return;
+        }
+        var oldAuth = (isHA ? "Hangman Admin" : "Super Hangman Admin");
         script.hangmanAdmins.remove(commandData);
         script.hangmanAdmins.remove(commandData.toLowerCase());
+        script.hangmanSuperAdmins.remove(commandData);
+        script.hangmanSuperAdmins.remove(commandData.toLowerCase());
         if (!silent) {
-            sys.sendAll("±Unown: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase() + " from Hangman Admin.", hangchan);
+            sys.sendAll("±Unown: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase() + " from " + oldAuth + ".", hangchan);
         }
-        sys.sendAll("±Unown: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase() + " from Hangman Admin.", sys.channelId('Victory Road'));
+        sys.sendAll("±Unown: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase() + " from " + oldAuth + ".", sys.channelId('Victory Road'));
         return;
     };
     this.demoteSuperAdmin = function (src, commandData, channel, silent) {

--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -3434,13 +3434,14 @@ function Mafia(mafiachan) {
         sma: ["/aliases: To check a user's known alts.",
             "/remove: To remove a Mafia Theme!",
             "/mafiaadmin: To promote a user to Mafia Admin. Use /smafiaadmin for a silent promotion.",
-            "/mafiasuperadmin: To promote a user to Super Mafia Admin. Use /smafiasuperadmin for a silent promotion.",
             "/mafiaadminoff: To strip a user of all Mafia authority. Use /smafiaadminoff for a silent demotion.",
             "/updateafter: To update mafia after current game!",
             "/updatestats: To update the mafia stats webpage (Use after mafiastat script changes)",
             "/featuretheme: To change the currently featured theme (Leave blank to disable Feature Themes)",
             "/votingthread: To update the link to the current Featured Theme Voting thread (Leave blank to remove URL and the line in the broadcast).",
             "/forcefeature: To force the \"Featured Theme\" message to display."]
+        owner: ["/mafiasuperadmin: To promote a user to Super Mafia Admin. Use /smafiasuperadmin for a silent promotion.",
+            "/mafiasuperadminoff: To demote a user from Super Mafia Admin. Use /smafiasuperadminoff for a silent demotion."]
     };
 
     this.handleCommand = function (src, message, channel) {
@@ -3453,7 +3454,7 @@ function Mafia(mafiachan) {
         } else {
             command = message.substr(0).toLowerCase();
         }
-        if (channel != mafiachan && ["mafiaban", "mafiaunban", "mafiabans", "mafiaadmins", "madmins", "mas", "roles", "priority", "sides", "themeinfo", "readlog", "targetlog", "disable", "enable", "enablenonpeak", "disablenonpeak", "mafiarules", "mafiaadminoff", "mafiaadmin", "mafiasadmin", "mafiasuperadmin", "smafiaadmin", "smafiasuperadmin", "smafiaadminoff", "passma", "windata", "topthemes", "updatestats"].indexOf(command) === -1)
+        if (channel != mafiachan && ["mafiaban", "mafiaunban", "mafiabans", "mafiaadmins", "madmins", "mas", "roles", "priority", "sides", "themeinfo", "readlog", "targetlog", "disable", "enable", "enablenonpeak", "disablenonpeak", "mafiarules", "mafiaadminoff", "mafiaadmin", "mafiasadmin", "mafiasuperadmin", "mafiasuperadminoff", "smafiaadmin", "smafiasuperadmin", "smafiaadminoff", "smafiasuperadminoff", "passma", "windata", "topthemes", "updatestats"].indexOf(command) === -1)
             return;
         try {
             mafia.handleCommandOld(src, command, commandData, channel);
@@ -4746,7 +4747,6 @@ function Mafia(mafiachan) {
             smas = smas.sort();
             sys.sendMessage(src, "", channel);
             sys.sendMessage(src, "*** MAFIA SUPER ADMINS ***", channel);
-            sys.sendMessage(src, "", channel);
             for (var i = 0; i < smas.length; i++) {
                 var id = sys.id(smas[i]);
                 if (!id) {
@@ -4764,7 +4764,6 @@ function Mafia(mafiachan) {
             if (script.hasAuthElements(mas)) {
                 sys.sendMessage(src, "", channel);
                 sys.sendMessage(src, "*** AUTH MAFIA ADMINS ***", channel);
-                sys.sendMessage(src, "", channel);
                 for (var i = 0; i < mas.length; i++) {
                     if (sys.dbAuths().indexOf(mas[i]) != -1) {
                         var id = sys.id(mas[i]);
@@ -4781,7 +4780,6 @@ function Mafia(mafiachan) {
             }
             sys.sendMessage(src, "", channel);
             sys.sendMessage(src, "*** MAFIA ADMINS ***", channel);
-            sys.sendMessage(src, "", channel);
             for (var i = 0; i < mas.length; i++) {
                 var id = sys.id(mas[i]);
                 if (!id) {
@@ -5017,6 +5015,18 @@ function Mafia(mafiachan) {
             sys.sendAll("±Murkrow: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase()  + " from " + (sMA ? "Super " : "") + "Mafia Admin.", sachannel);
             return;
         }
+        if (command === "mafiasadminoff" || command === "mafiasuperadminoff" || command === "smafiasadminoff" || command === "smafiasuperadminoff") {
+            var silent = (command === "smafiasuperadminoff" || command === "smafiasadminoff");
+            script.mafiaSuperAdmins.remove(commandData.toLowerCase());
+            if (id !== undefined) {
+                SESSION.users(id).mafiaAdmin = false;
+            }
+            if (!silent) {
+                sys.sendAll("±Murkrow: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase()  + " from Super Mafia Admin.", mafiachan);
+            }
+            sys.sendAll("±Murkrow: " + nonFlashing(sys.name(src)) + " demoted " + commandData.toCorrectCase()  + " from Super Mafia Admin.", sachannel);
+            return;
+        }
         if (command === "remove" || command === "sremove"){
             var silent = (command === "sremove");
             mafia.themeManager.remove(src, commandData, silent);
@@ -5167,6 +5177,12 @@ function Mafia(mafiachan) {
             if (this.isMafiaSuperAdmin(src)) {
                 sys.sendMessage(src, "*** Super Mafia Admin commands ***", channel);
                 this.commands.sma.forEach(function (x) {
+                    sys.sendMessage(src, x, channel);
+                });
+            }
+            if (sys.auth(src) >= 3) {
+                sys.sendMessage(src, "*** Super Mafia Admin commands ***", channel);
+                this.commands.owner.forEach(function (x) {
                     sys.sendMessage(src, x, channel);
                 });
             }

--- a/scripts/ownercommands.js
+++ b/scripts/ownercommands.js
@@ -698,7 +698,6 @@ exports.help =
         "/updatetierchecks: To update tier checks.",
         "/updatecommands: To update command files.",
         "/updatetiers[soft]: To update tiers. Soft saves to file only without reloading.",
-        "/tourowner: Makes a user a Tournament Owner. Use /stowner for a silent promotion.",
         "/loadstats: Loads the usage stats plugin.",
         "/unloadstats: Unloads the usage stats plugin.",
         "/warnwebclients: Sends a big alert with your message to webclient users.",

--- a/scripts/tours.js
+++ b/scripts/tours.js
@@ -109,6 +109,8 @@ var tourownercommands = ["/megauser: Makes someone a megauser. Use /smegauser fo
                     "/fullleaderboard: Gives the full leaderboard for a specified tier.",
                     "/fullmonthlyleaderboard: Gives the full monthly leaderboard for a specified month.",
                     "/loadevents: Load event tours."];
+var serverownercommands = ["/tourowner: Makes someone a Tournament Owner. Use /stowner for a silent promotion.",
+                    "/
 var tourrules = ["*** TOURNAMENT GUIDELINES ***",
                 "Breaking the following rules may result in punishment:",
                 "#1: Team revealing or scouting in tiers other than CC, Battle Factory or Metronome will result in disqualification.",
@@ -1475,12 +1477,12 @@ function tourCommand(src, command, commandData, channel) {
                 var tadmins = tours.touradmins;
                 var silent = (command === "smegauseroff");
                 if (sys.dbIp(commandData) === undefined) {
-                    sendBotMessage(src, "This user doesn't exist!", tourschan, false);
+                    sendBotMessage(src, "That user doesn't exist!", tourschan, false);
                     return true;
                 }
                 var lname = commandData.toLowerCase();
                 if (!tadmins.hasOwnProperty(lname)) {
-                    sendBotMessage(src, "They don't have tour authority!", tourschan, false);
+                    sendBotMessage(src, "That user doesn't have tour authority!", tourschan, false);
                     return true;
                 }
                 if ((tadmins[lname] == "to")  && sys.auth(src) < 3) {
@@ -1496,6 +1498,33 @@ function tourCommand(src, command, commandData, channel) {
                 }
                 else {
                     sendBotAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from " + oldauth + ".", sys.channelId("Victory Road"), false);
+                }
+                return true;
+            }
+            if ((command === "tourowneroff" || command === "towneroff" || command === "stourowneroff" || command === "stowneroff") && sys.auth(src) >= 3) {
+                var tadmins = tours.touradmins;
+                var silent = (command === "stourowneroff" || command === "stowneroff");
+                if (sys.dbIp(commandData) === undefined) {
+                    sendBotMessage(src, "That user doesn't exist!", tourschan, false);
+                    return true;
+                }
+                var lname = commandData.toLowerCase();
+                if (!tadmins.hasOwnProperty(lname)) {
+                    sendBotMessage(src, "That user doesn't have tour authority!", tourschan, false);
+                    return true;
+                }
+                if (tadmins[lname] != "to") {
+                    sendBotMessage(src, "That user isn't a Tour Owner!", tourschan, false);
+                    return true;
+                }
+                delete tadmins[lname];
+                tours.touradmins = tadmins;
+                saveTourKeys();
+                if (!silent) {
+                    sendBotAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from Tournament Owner.", "~tr", false);
+                }
+                else {
+                    sendBotAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from Tournament Owner.", sys.channelId("Victory Road"), false);
                 }
                 return true;
             }
@@ -2249,6 +2278,7 @@ function tourCommand(src, command, commandData, channel) {
                     var index = tours.tour[key].players.indexOf(commandData.toLowerCase());
                     tours.tour[key].players.splice(index, 1);
                     tours.tour[key].cpt -= 1;
+                    tours.tour[key].dqs.push(sys.ip(commandData));
                     sendBotAll(toCorrectCase(commandData)+" was taken out of the tournament signups by "+sys.name(src)+" from the "+getFullTourName(key)+" tournament!", tourschan);
                 }
                 else {
@@ -2460,7 +2490,11 @@ function tourCommand(src, command, commandData, channel) {
                 }
             }
             if (key === null) {
-                sendBotMessage(src, "No tournament has signups available at the moment!",tourschan,false);
+                sendBotMessage(src, "No tournament has signups available at the moment!", tourschan, false);
+                return true;
+            }
+            if (tours.tour[key].dqs.indexOf(sys.ip(src)) != -1) {
+                sendBotMessage(src, "You were removed from signups, so you can't join again!", tourschan, false);
                 return true;
             }
             if (!sys.hasTier(src, tours.tour[key].tourtype)) {
@@ -2783,7 +2817,6 @@ function tourCommand(src, command, commandData, channel) {
             mus.sort();
             sys.sendMessage(src, "", channel);
             sys.sendMessage(src, "*** TOURNAMENT OWNERS ***", channel);
-            sys.sendMessage(src, "", channel);
             for (var o in tos) {
                 var id = sys.id(tos[o]);
                 if (!id) {
@@ -2796,7 +2829,6 @@ function tourCommand(src, command, commandData, channel) {
             if (script.hasAuthElements(mus)) {
                 sys.sendMessage(src, "", channel);
                 sys.sendMessage(src, "*** AUTH MEGAUSERS ***", channel);
-                sys.sendMessage(src, "", channel);
                 for (var m in mus) {
                     if (sys.dbAuths().indexOf(mus[m]) != -1) {
                         var id = sys.id(mus[m]);
@@ -2813,7 +2845,6 @@ function tourCommand(src, command, commandData, channel) {
             }
             sys.sendMessage(src, "", channel);
             sys.sendMessage(src, "*** MEGAUSERS ***", channel);
-            sys.sendMessage(src, "", channel);
             for (var m in mus) {
                 var id = sys.id(mus[m]);
                 if (!id) {
@@ -3515,6 +3546,7 @@ function tourstart(tier, starter, key, parameters) {
         tours.tour[key].date = datestring; // used to identify event tours
         tours.tour[key].draws = [];
         tours.tour[key].numjoins = {};
+        tours.tour[key].dqs = [];
         tours.globaltime = 0;
         if (typeof parameters.maxplayers === "number" && parameters.event) {
             tours.tour[key].maxplayers = parameters.maxplayers;
@@ -4546,7 +4578,7 @@ module.exports = {
         else {
             command = message.substr(0).toLowerCase();
         }
-        var globalcommands = ["towner", "megauser", "megauseroff", "megausers", "mus"];
+        var globalcommands = ["towner", "tourowner", "stowner", "stourowner", "tourowneroff", "towneroff", "stourowneroff", "stowneroff",  "megauser",  "megauseroff", "smegauser", "smegauseroff" "megausers", "mus"];
         if ((channel === tourschan && !SESSION.channels(tourschan).isBanned(source)) || globalcommands.indexOf(command) > -1) {
             return tourCommand(source, command, commandData, channel);
         }
@@ -4685,6 +4717,12 @@ module.exports = {
                 sys.sendMessage(src, "*** Tournaments Owner commands ***", channel);
                 for (var o in tourownercommands) {
                     sys.sendMessage(src, tourownercommands[o], channel);
+                }
+            }
+            if (sys.auth(src) >= 3) {
+                sys.sendMessage(src, "*** Server owner Tournament commands ***", channel);
+                for (var x in serverownercommands) {
+                    sys.sendMessage(src, serverownercommands[x], channel);
                 }
             }
         }

--- a/scripts/trivia.js
+++ b/scripts/trivia.js
@@ -878,7 +878,6 @@ TriviaAdmin.prototype.tAdminList = function (src, id, type) {
         if (script.hasAuthElements(tadmins)) {
             sys.sendMessage(src, "", id);
             sys.sendMessage(src, "*** AUTH TRIVIA ADMINS ***", id);
-            sys.sendMessage(src, "", id);
             for (var b in tadmins) {
                 if (sys.dbAuths().indexOf(tadmins[b]) != -1) {
                     if (sys.id(tadmins[b]) === undefined) {
@@ -895,7 +894,6 @@ TriviaAdmin.prototype.tAdminList = function (src, id, type) {
     }
     sys.sendMessage(src, "", id);
     sys.sendMessage(src, "*** " + type.toUpperCase() + " ***", id);
-    sys.sendMessage(src, "", id);
     for (var b in tadmins) {
         if (sys.id(tadmins[b]) === undefined) {
             sys.sendMessage(src, tadmins[b], id);
@@ -911,9 +909,11 @@ TriviaAdmin.prototype.tAdminList = function (src, id, type) {
 var userCommands = {};
 var adminCommands = {};
 var ownerCommands = {};
+var serverOwnerCommands = {};
 var userCommandHelp = [];
 var adminCommandHelp = [];
 var ownerCommandHelp = [];
+var serverOnwerCommandHelp = [];
 
 function addUserCommand(commands, callback, help) {
     commands = [].concat(commands);
@@ -937,6 +937,14 @@ function addOwnerCommand(commands, callback, help) {
         ownerCommands[commands[i]] = callback;
     }
     ownerCommandHelp.push("/" + commands[0] + ": " + (help === undefined ? "no help" : help));
+}
+
+function addServerOwnerCommand(commands, callback, help) {
+    commands = [].concat(commands);
+        for (var i = 0; i < commands.length; ++i) {
+        serverOwnerCommands[commands[i]] = callback;
+    }
+    serverOwnerCommandHelp.push("/" + commands[0] + ": " + (help === undefined ? "no help" : help));
 }
 
 addUserCommand("triviarules", function (src, commandData, channel) {
@@ -1106,19 +1114,26 @@ addOwnerCommand(["triviaadmin", "striviaadmin"], function (src, commandData, cha
 }, "Allows you to promote a new trivia admin, use /striviaadmin for a silent promotion.");
 
 addOwnerCommand(["triviaadminoff", "striviaadminoff"], function (src, commandData, channel, command) {
-    if (!tadmin.isTAdmin(commandData)) {
-        Trivia.sendPM(src, "That person isn't a Trivia Admin.", channel);
+    if (!tadmin.isTAdmin(commandData) && !tsadmin.isTAdmin(commandData)) {
+        Trivia.sendPM(src, "That person isn't a Trivia auth.", channel);
         return;
     }
-    tadmin.removeTAdmin(commandData);
-    if (command === "triviaadminoff") {
-        Trivia.sendAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from Trivia Admin.", triviachan);
+    var isTA = tadmin.isTAdmin(commandData);
+    var oldAuth = (isTA ? "Trivia Admin" : "Super Trivia Admin");
+    if (isTA) {
+        tadmin.removeTAdmin(commandData);
     }
-    Trivia.sendAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from Trivia Admin.", revchan);
-    Trivia.sendAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from Trivia Admin.", sachannel);
-}, "Allows you to demote a current trivia admin, use /strivaadminoff for a silent demotion.");
+    else {
+        tsadmin.removeTAdmin(commandData);
+    }
+    if (command === "triviaadminoff") {
+        Trivia.sendAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from " + oldAuth + ".", triviachan);
+    }
+    Trivia.sendAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from " + oldAuth + ".", revchan);
+    Trivia.sendAll(sys.name(src) + " demoted " + commandData.toCorrectCase() + " from " + oldAuth + ".", sachannel);
+}, "Allows you to demote a current trivia admin or super trivia admin, use /striviaadminoff for a silent demotion.");
 
-addOwnerCommand(["triviasuperadmin", "striviasuperadmin"], function (src, commandData, channel, command) {
+addServerOwnerCommand(["triviasuperadmin", "striviasuperadmin"], function (src, commandData, channel, command) {
     if (tsadmin.isTAdmin(commandData)) {
         Trivia.sendPM(src, "That person is already a Trivia Super Admin.", channel);
         return;
@@ -1131,7 +1146,7 @@ addOwnerCommand(["triviasuperadmin", "striviasuperadmin"], function (src, comman
     Trivia.sendAll(sys.name(src) + " promoted " + commandData.toCorrectCase() + " to Super Trivia Admin.", sachannel);
 }, "Allows you to promote a new trivia super admin, use /striviasuperadmin for a silent promotion.");
 
-addOwnerCommand(["triviasuperadminoff", "striviasuperadminoff"], function (src, commandData, channel, command) {
+addServerOwnerCommand(["triviasuperadminoff", "striviasuperadminoff"], function (src, commandData, channel, command) {
     if (!tsadmin.isTAdmin(commandData)) {
         Trivia.sendPM(src, "That person isn't a Trivia Super Admin.", channel);
         return;
@@ -1598,23 +1613,6 @@ addAdminCommand("decline", function (src, commandData, channel) {
     triviabot.sendMessage(src, "No more questions!", channel);
 }, "Allows you to decline the current question in review");
 
-addAdminCommand("shove", function (src, commandData) {
-    var tar = sys.id(commandData);
-    if (tar === undefined) {
-        return;
-    }
-    if (Trivia.started === false) {
-        Trivia.sendPM(src, "A game hasn't started!");
-        return;
-    }
-    if (Trivia.playerPlaying(tar)) {
-        Trivia.removePlayer(tar);
-        Trivia.sendAll(sys.name(tar) + " was removed from the game by " + sys.name(src) + "!", triviachan);
-        return;
-    }
-    Trivia.sendPM(src, "That person isn't playing!");
-}, "Allows you to remove a player from the game");
-
 addAdminCommand("submitban", function (src, commandData, channel) {
     if (commandData === undefined || commandData.indexOf(":") == -1) {
         triviabot.sendMessage(src, "Usage: name:reason:time", channel);
@@ -1880,6 +1878,13 @@ module.exports = {
                     return true;
                 }
             }
+            // Server owner trivia commands
+            if (sys.auth(src) >= 3) {
+                if (serverOwnerCommands.hasOwnProperty(command)) {
+                    serverOwnerCommands[command].call(null, src, commandData, channel, command);
+                    return true;
+                }
+            }
         }
         catch (e) {
             sys.sendMessage(src, "Error in your trivia command: " + e + " on line " + e.lineNumber, channel);
@@ -1902,6 +1907,12 @@ module.exports = {
             if (isTriviaOwner(src)) {
                 sys.sendMessage(src, "*** Trivia Owner commands ***", channel);
                 ownerCommandHelp.forEach(function (h) {
+                    sys.sendMessage(src, h, channel);
+                });
+            }
+            if (sys.auth(src) >= 3) {
+                sys.sendMessage(src, "*** Server owner Trivia commands ***", channel);
+                serverOwnerCommandHelp.forEach(function (h) {
                     sys.sendMessage(src, h, channel);
                 });
             }


### PR DESCRIPTION
Removed /shove from Trivia, made DQ'd users unable to rejoin a tour during signups, made /triviaadminoff and similar work for both auth and super auth, made a separate command listing for server owners.
