### PR TITLE
Mafia: Theme variables

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -364,13 +364,9 @@ function Mafia(mafiachan) {
         sys.writeToFile("mafiathemes/metadata.json", JSON.stringify({ 'meta': this.themeInfo }));
     };
 
-    ThemeManager.prototype.loadTheme = function (raw_theme) {
+    ThemeManager.prototype.loadTheme = function (plain_theme) {
         var theme = new Theme();
         try {
-            // Slow and lazy way to copy a theme                    
-            // if anyone wants to improve this, go ahead.
-            var plain_theme = JSON.parse(JSON.stringify(raw_theme)); 
-            
             theme.sideTranslations = {};
             theme.sideWinMsg = {};
             theme.roles = {};
@@ -477,7 +473,8 @@ function Mafia(mafiachan) {
             try {
                 var plain_theme = JSON.parse(resp);
                 
-                var errors = mafia.mafiaChecker.checkTheme(plain_theme);
+                // Create a copy to prevent the checker from changing the theme.
+                var errors = mafia.mafiaChecker.checkTheme(JSON.parse(resp));
                 if (errors.fatal.length > 0) {
                     sys.sendMessage(src, "", mafiachan);
                     msg(src, "Fatal Errors found in the theme: ");
@@ -504,6 +501,7 @@ function Mafia(mafiachan) {
                     return;
                 }
                 
+                // Don't care about loadTheme changing plain_theme as it's not being reused.
                 var theme = manager.loadTheme(plain_theme);
                 var lower = theme.name.toLowerCase();
                 var needsDisable = false;

--- a/scripts/mafiachecker.js
+++ b/scripts/mafiachecker.js
@@ -1212,6 +1212,7 @@ function mafiaChecker() {
         
         if (typeof prop === 'string' && prop.slice(0, 9) === 'variable:') {
             variable = prop.slice(9);
+            // Check for undefined variable here.
             master[index] = variables[variable];
         } else if (Array.isArray(prop)) {
             for (j = 0, len = prop.length; j < len; j += 1) {


### PR DESCRIPTION
This will parse variable:(name) strings in theme properties (this means **anything** can be a string now, with the exception of the 'variables' global theme property). **This doesn't add new gameplay features, it only simplifies certain themes massively (by making code reusable easily)**.

It will only affect themes that have a 'variables' global, old themes are untouched.

@IceKirby I had to copy some of the code to the theme checker for it to accept the theme, you'll probably want to change it.

Test theme used: http://pastebin.com/raw.php?i=buWYXTUq 

I'll make a post on the how to make themes thread later (once this is accepted of course) with a better example theme.
