### PR TITLE
Mafia: role.players

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -4509,7 +4509,9 @@ function Mafia(mafiachan) {
                     if (roles[i].search(/±role:/i) > -1 && roles[i].toLowerCase().search(roleTranslation) > -1) {
                         filterRoles.push(roles[i]);
                         filterRoles.push(roles[i + 1]);
-                        filterRoles.push(roles[i + 2]);
+                        if (roles[i + 2].substr(0, 9) === "±Players:") {
+                            filterRoles.push(roles[i + 2]);
+                        }
                         filterRoles.push(sep);
                     }
                 }


### PR DESCRIPTION
This lets you set a custom value for the ±Players: part of /roles

Accepts types:
- string `"players": "Convert only"`: ±Players: Convert only
- number `"players": 3`: ±Players: 3 Players
- array `"players": [3, 10]`: ±Players: 3-10 Players
- boolean (only false) `"players": false`: Nothing.
