### PR TITLE
Prevent shovelist msg from displaying if user isn't actually being shoved

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -1238,7 +1238,7 @@ function Mafia(mafiachan) {
             border = DEFAULT_BORDER;
             sendChanAll("", mafiachan);
             sendChanAll(border, mafiachan);
-            sendChanAll("±Game: " + sys.name(src) + " started a voting for next game's theme!. You have " + this.ticks + " seconds to vote with /vote or /votetheme!", mafiachan);
+            sendChanAll("±Game: " + sys.name(src) + " started a voting for next game's theme! You have " + this.ticks + " seconds to vote with /vote or /votetheme!", mafiachan);
             var casedThemes = [];
             for (var x in this.possibleThemes) {
                 casedThemes.push(this.themeManager.themes[x].name);
@@ -5590,6 +5590,7 @@ function Mafia(mafiachan) {
         } else if (this.isInGame(id)) {
             this.slayUser(mafiabot.name, id, false);
         }
+        delete mafia.usersToShove[id];
         if (sys.isInChannel(src, mafiachan)) {
             sys.kick(src, mafiachan);
         }
@@ -5603,6 +5604,7 @@ function Mafia(mafiachan) {
         } else if (this.isInGame(dest)) {
             this.slayUser(mafiabot.name, dest, false);
         }
+        delete mafia.usersToShove[dest];
     };
     
     /*Not sure what this is for, onMute is called for Blaziken.. Whatever it is, I can't test if it works or not.


### PR DESCRIPTION
If the player was set to be shoved, it would have shoved by then. If the player was not set to be shoved, it deletes it and bypasses the message.
