### PR TITLE
Hangman: Adding hint to Tohjo advertisement

### DIFF
--- a/scripts/hangman.js
+++ b/scripts/hangman.js
@@ -223,6 +223,7 @@ module.exports = function () {
         }
         else {
             this.addMiss(src);
+            this.applyPoints(src, 0);
             this.addAnswerUse(src);
             hangbot.sendAll("" + sys.name(src) + "'s answer was wrong! The game continues!", hangchan);
             sendChanHtmlAll(" ", hangchan);


### PR DESCRIPTION
As requested by Stocke

Also fixing a long overdue error where player's name would not appear when a game finishes if they only used /a.
