### PR TITLE
Fix green name issue...?

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -2092,7 +2092,9 @@ beforeChatMessage: function(src, message, chan) {
         } else {
             sys.playerIds().forEach(function(id) {
                 if (sys.loggedIn(id) && SESSION.users(id).smute.active) {
-                    sys.sendMessage(id,  sys.name(src)+": "+message, channel);
+                    //sys.sendMessage(id,  sys.name(src)+": "+message, channel);
+                    var color = getColor(id);
+                    sys.sendHtmlMessage(id, "<font color="+color+"><timestamp/><b>"+sys.name(src)+"</b></font>: "+ utilities.html_escape(message), channel);
                 }
             });
             sys.stopEvent();


### PR DESCRIPTION
I can't really test if this fixes it on android cause no android device. 
Also, scripts are a pain to test on my end.

The android code that would handle is https://github.com/po-devs/android-client/blob/master/src/com/podevs/android/pokemononline/chat/Channel.java#L116-168 but that part is commented out. Welcome message + Auth are already formatted correctly (which is probably the reason for the commented code) but it seems that block of code would also handle this function. I'm not sure though, remember that I'm a terrible coder.
