### PR TITLE
Force the use of /say to all but server staff+sMA

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -5517,7 +5517,7 @@ function Mafia(mafiachan) {
                     return true;
                 }
             } 
-            if (!mafia.isInGame(sys.name(src)) && sys.auth(src) <= 0 && !mafia.isMafiaAdmin(src)) {
+            if (!mafia.isInGame(sys.name(src)) && sys.auth(src) <= 0 && !mafia.isMafiaSuperAdmin(src)) {
                 if (!(is_command(message) && message.substr(1, 2).toLowerCase() != "me")) {
                     sys.sendMessage(src, Config.Mafia.notPlayingMsg, mafiachan);
                     return true;


### PR DESCRIPTION
This way it wont intrude too much on moderating the channel, but then MAs cant accidentally deadtalk, which has occurred before.
Haven't seen auth or sMA slip yet, more careful maybe? lol
