### PR TITLE
Make android unable to join doubles/triples (fix)

### DIFF
--- a/scripts/tours.js
+++ b/scripts/tours.js
@@ -2504,7 +2504,7 @@ function tourCommand(src, command, commandData, channel) {
                 sendBotMessage(src, "You need to "+(needsteam ? "have a team for" : "change your tier to")+" the "+tours.tour[key].tourtype+" tier to join!",tourschan,false);
                 return true;
             }
-            if ((tours.tour[key].parameters.mode === "Doubles" || tours.tour[key].parameters.mode === "Triples") && sys.users(src).android) {
+            if ((tours.tour[key].parameters.mode === "Doubles" || tours.tour[key].parameters.mode === "Triples") && sys.os(src) === "android") {
                 sendBotMessage(src, "Android devices are incapable of joining "+tours.tour[key].parameters.mode+" tours!",tourschan,false);
                 return true;
             }


### PR DESCRIPTION
Moogle says 'sys.os(src) === "android"' actually detects android, as opposed to w/e I was using.
