### PR TITLE
Fix error when using certain commands(?)

### DIFF
--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -10,7 +10,7 @@ exports.handleCommand = function(src, command, commandData, tar, channel) {
     if (modCommands === undefined) {
         modCommands = require("modcommands.js");
     }
-    if (sys.auth(src) > 0 || SESSION.users(src).tempMod || (script.isMafiaAdmin(src) || script.isMafiaSuperAdmin(src)) && command == "mafiabans" || script.isMafiaSuperAdmin(src) && command == "aliases") {
+    if (sys.auth(src) > 0 || SESSION.users(src).tempMod || ((script.isMafiaAdmin(src) || script.isMafiaSuperAdmin(src)) && command == "mafiabans") || (script.isMafiaSuperAdmin(src) && command == "aliases")) {
         if (modCommands.handleCommand(src, command, commandData, tar, channel) != "no command") {
             return;
         }


### PR DESCRIPTION
(20:24:57) Atli2: cauth commands don't work with this alt?
(20:25:03) +Fuzzysqurl3: Script Error line 13: TypeError: Result of
expression 'script.isMafiaAdmin' [undefined] is not a function.
(20:25:03) +Fuzzysqurl3: <anonymous>(src = 93, command = 'member',
commandData = 'atli', tar = 92, channel = 2) at 13
(20:25:03) +Fuzzysqurl3: <anonymous>(src = 93, message = '/member atli',
chan = 2) at scripts.js:1788
(20:25:03) +Fuzzysqurl3: <global>() at -1

(20:48:00) Fuzzysqurl: -- Command: Fuzzysqurl: /owner Atli
(20:48:00) Fuzzysqurl: Script Error line 13: TypeError: Result of expression 'script.isMafiaAdmin' [undefined] is not a function.
(20:48:00) Fuzzysqurl: <anonymous>(src = 89, command = 'owner', commandData = 'Atli', tar = 98, channel = 2) at 13
(20:48:00) Fuzzysqurl: <anonymous>(src = 89, message = '/owner Atli', chan = 2) at scripts.js:1788
(20:48:00) Fuzzysqurl: <global>() at -1

Error stopped showing up after I fixed the parentheses and commands resumed working, so I assume this needed to be fixed.
