### PR TITLE
Pass channel auth

### DIFF
--- a/scripts/channelfunctions.js
+++ b/scripts/channelfunctions.js
@@ -100,6 +100,22 @@ POChannel.prototype.isChannelOperator = function(id)
     }
     return false;
 };
+POChannel.prototype.isChannelMember = function(id)
+{
+    if (!sys.dbRegistered(sys.name(id))) {
+        return false;
+    }
+    if ((sys.auth(id) >= 1 && this.id === 0) || this.isChannelOperator(id) || this.isChannelAdmin(id) || this.isChannelOwner(id)) {
+        return true;
+    }
+    if (typeof this.members != "object") {
+        this.members = [];
+    }
+    if (this.members.indexOf(sys.name(id).toLowerCase()) > -1) {
+        return true;
+    }
+    return false;
+};
 
 POChannel.prototype.addRole = function(src, tar, group, data)
 {


### PR DESCRIPTION
This way was the best I found that worked. Couldn't use takeAuth and
issueAuth because they are restricted based on your current channel
position. For example, Admin couldn't pass admin, but could pass op and
member (because they can normally give users those spots).

Could probably use some tweaking here and there, but it works as is and doesn't let someone hand out auth they don't have (such as a channel admin passing owners)
