### PR TITLE
Mafia: Fix rare bug

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -2750,7 +2750,7 @@ function Mafia(mafiachan) {
                 var rolecheck;
                 var teamcheck;
                 for (j = 0; j < names.length; ++j) {
-                    if (!mafia.isInGame(names[j]) || mafia.hasCommand(names[j], o.action, "night") === false) continue;
+                    if (!mafia.isInGame(names[j]) || mafia.hasCommand(names[j], o.action, "night") === false || mafia.players[names[j]].role.role !== o.role) continue;
                     player = mafia.players[names[j]];
                     var targets = mafia.getTargetsFor(player, o.action);
                     var target, t; // current target


### PR DESCRIPTION
A bug so rare that it took a theme as complex as Shop to find it.
Basically, if 2 players have the same role (identical role ID) and one of them use a night action which can end converting the other (convert/massconvert/onDeath), the converted player may get weird results if they tried to use the same action.
