### PR TITLE
commandData for /idle now accepts both cases for off/on

### DIFF
--- a/scripts/usercommands.js
+++ b/scripts/usercommands.js
@@ -291,11 +291,11 @@ exports.handleCommand = function(src, command, commandData, tar, channel) {
         return;
     }
     if (command == "idle") {
-        if (commandData == "on") {
+        if (commandData.toLowerCase() == "on") {
             battlebot.sendMessage(src, "You are now idling.", channel);
             script.saveKey("autoIdle", src, 1);
             sys.changeAway(src, true);
-        } else if (commandData == "off") {
+        } else if (commandData.toLowerCase() == "off") {
             battlebot.sendMessage(src, "You are back and ready for battles!", channel);
             script.saveKey("autoIdle", src, 0);
             sys.changeAway(src, false);


### PR DESCRIPTION
Fiery Espeon found using /idle with command data off and on in caps breaks it. This update allows both lower and upper casing of the command data to work.