### PR TITLE
Make t like .

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1622,8 +1622,8 @@ beforeChatMessage: function(src, message, chan) {
     }
 
 
-    if (message == ".") {
-        sys.sendMessage(src, sys.name(src)+": .", channel);
+    if (message == "." || message == "t") {
+        sys.sendMessage(src, sys.name(src)+": "+message, channel);
         sys.stopEvent();
         this.afterChatMessage(src, message, chan);
         return;


### PR DESCRIPTION
It's becoming quite ridiculous now in Tohjo. "t" messages out number real messages at slower times. And its near impossible to communicate that using "." is better because there is a language barrier causing problems, since most of the "t" users speak chinese exclusively.