### PR TITLE
Mafia: More features and tweaks

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -5303,7 +5303,9 @@ function Mafia(mafiachan) {
                     var inspectMode = target.role.actions.inspect || {};
                     var revealedRole;
                     var revealedSide;
-                    if (inspectMode.revealAs !== undefined) {
+                    if (target.disguiseRole !== undefined) {
+                        revealedRole = mafia.theme.trrole(target.disguiseRole);
+                    } else if (inspectMode.revealAs !== undefined) {
                         if (typeof inspectMode.revealAs == "string") {
                             if (inspectMode.revealAs == "*") {
                                 var rrole = Object.keys(mafia.players).map(function(x) { return mafia.players[x].role.role; }, mafia);

--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -523,6 +523,8 @@ function Mafia(mafiachan) {
             theme.killusermsg = plain_theme.killusermsg;
             theme.drawmsg = plain_theme.drawmsg;
             theme.lynchmsg = plain_theme.lynchmsg;
+            theme.tiedvotemsg = plain_theme.tiedvotemsg;
+            theme.novotemsg = plain_theme.novotemsg;
             theme.delayedConversionMsg = plain_theme.delayedConversionMsg || false;
             theme.noplur = plain_theme.noplur;
             theme.border = plain_theme.border;
@@ -1335,6 +1337,7 @@ function Mafia(mafiachan) {
             this.players[p].protectmsg = undefined;
             this.players[p].safeguardmsg = undefined;
             this.players[p].guardmsg= undefined;
+            this.players[p].haxCount = {};
         }
     };
     this.clearVariables();
@@ -1384,9 +1387,16 @@ function Mafia(mafiachan) {
         if (this.invalidName(src))
             return;
 
+        var now = (new Date()).getTime();
+        
         var themeName = commandData.toLowerCase();
         var reason;
         if (this.state == "blank") {
+            if (SESSION.users(src).mafia_start !== undefined && SESSION.users(src).mafia_start + 5000 > now && !this.isMafiaSuperAdmin(src)) {
+                gamemsg(srcname, "Wait a moment before trying to start again!");
+                return;
+            }
+            SESSION.users(src).mafia_start = now;
             this.state = "voting";
             this.ticks = 20;
             this.votes = {};
@@ -1459,6 +1469,11 @@ function Mafia(mafiachan) {
             sendChanAll("", mafiachan);
         }
         if (this.state != "voting") {
+            if (SESSION.users(src).mafia_start !== undefined && SESSION.users(src).mafia_start + 5000 > now && !this.isMafiaSuperAdmin(src)) {
+                gamemsg(srcname, "Wait a moment before trying to start again!");
+                return;
+            }
+            SESSION.users(src).mafia_start = now;
             gamemsg(srcname, "You can only vote during the voting phase!");
             return;
         }
@@ -1958,7 +1973,7 @@ function Mafia(mafiachan) {
         }
     };
     this.compulsoryActions = function() {
-        var p, player, role, a, action, users, list, target, command,
+        var p, player, role, a, e, action, users, list, target, command, limit, picked, charges,
             selfUsers = {}, roleUsers = {}, teamUsers = {};
         for (p in this.players) {
             player = this.players[p];
@@ -1997,8 +2012,20 @@ function Mafia(mafiachan) {
                 action = role.actions.night[command];
                 list = this.findPossibleTargets(player, action.target);
                 if (list.length > 0) {
-                    target = list[sys.rand(0, list.length)];
-                    this.inputNightCommand(player.name, command, target);
+                    limit = action.limit || 1;
+                    charges = mafia.getCharges(player, "night", command);
+                    if (charges !== undefined && limit > charges) {
+                        limit = charges;
+                    }
+                    for (e = 0; e < limit; e++) {
+                        picked = sys.rand(0, list.length);
+                        target = list[picked];
+                        list.splice(picked, 1);
+                        this.inputNightCommand(player.name, command, target);
+                        if (list.length === 0) {
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -2013,8 +2040,20 @@ function Mafia(mafiachan) {
                 action = role.actions.night[command];
                 list = this.findPossibleTargets(player, action.target);
                 if (list.length > 0) {
-                    target = list[sys.rand(0, list.length)];
-                    this.inputNightCommand(player.name, command, target);
+                    limit = action.limit || 1;
+                    charges = mafia.getCharges(player, "night", command);
+                    if (charges !== undefined && limit > charges) {
+                        limit = charges;
+                    }
+                    for (e = 0; e < limit; e++) {
+                        picked = sys.rand(0, list.length);
+                        target = list[picked];
+                        list.splice(picked, 1);
+                        this.inputNightCommand(player.name, command, target);
+                        if (list.length === 0) {
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -2038,8 +2077,20 @@ function Mafia(mafiachan) {
                 action = role.actions.night[command];
                 list = this.findPossibleTargets(player, action.target);
                 if (list.length > 0) {
-                    target = list[sys.rand(0, list.length)];
-                    this.inputNightCommand(player.name, command, target);
+                    limit = action.limit || 1;
+                    charges = mafia.getCharges(player, "night", command);
+                    if (charges !== undefined && limit > charges) {
+                        limit = charges;
+                    }
+                    for (e = 0; e < limit; e++) {
+                        picked = sys.rand(0, list.length);
+                        target = list[picked];
+                        list.splice(picked, 1);
+                        this.inputNightCommand(player.name, command, target);
+                        if (list.length === 0) {
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -2454,6 +2505,7 @@ function Mafia(mafiachan) {
     this.voteForPlayer = function(src, commandData, canVoteTeam) {
         var silentVote = mafia.theme.silentVote;
         var name = sys.name(src);
+        SESSION.users(src).mafia_start = (new Date()).getTime();
         if (!this.isInGame(commandData)) {
             gamemsg(name, "That person is not playing!");
             return;
@@ -3065,7 +3117,7 @@ function Mafia(mafiachan) {
                             var finalCurseCount = Action.curseCount || 2;
                             var commandIsDummy = isDummyCommand.test(command);
 
-                            if (["kill", "protect", "inspect", "distract", "poison", "safeguard", "stalk", "watch", "convert", "copy", "curse", "detox", "dispel", "shield", "guard", "massconvert"].indexOf(command) === -1 && !commandIsDummy) {
+                            if (["kill", "protect", "inspect", "distract", "poison", "safeguard", "stalk", "watch", "convert", "copy", "curse", "detox", "dispel", "shield", "guard", "massconvert", "disguise"].indexOf(command) === -1 && !commandIsDummy) {
                                 continue;
                             }
                             if (!mafia.isInGame(target)) {
@@ -3078,11 +3130,14 @@ function Mafia(mafiachan) {
                                 if (("pierceChance" in Action && Action.pierceChance > Math.random()) || Action.pierce === true) {
                                     piercing = true;
                                 }
+                                if (commandIsDummy && (command + "Pierce") in Action && Action[command + "Pierce"] === true) {
+                                    piercing = true;
+                                }
                                 if (piercing !== true && target.guardActions.indexOf(o.action) !== -1) {
                                     gamemsg(player.name, target.guardmsg.replace(/~Command~/g, o.action));
                                     continue outer;
                                 }
-                                if (piercing !== true && ((target.guarded && command == "kill") || (target.safeguarded && (["distract", "inspect", "stalk", "watch", "poison", "convert", "copy", "curse", "detox", "dispel", "massconvert"].indexOf(command) !== -1 || commandIsDummy)))) {
+                                if (piercing !== true && ((target.guarded && command == "kill") || (target.safeguarded && (["distract", "inspect", "stalk", "watch", "poison", "convert", "copy", "curse", "detox", "dispel", "massconvert", "disguise"].indexOf(command) !== -1 || commandIsDummy)))) {
                                     gamemsg(player.name, (command == "kill" ? target.protectmsg : target.safeguardmsg));
                                     // Action can be countered even if target is protected/guarded
                                     if (command in target.role.actions) {
@@ -3349,29 +3404,44 @@ function Mafia(mafiachan) {
                                 var Sight = Action.Sight;
                                 targetMode = targetMode || {};
                                 var inspectMode = target.role.actions.inspect || {};
-                                if (targetMode.revealSide !== undefined || Sight === "Team") {
-                                    var revealedSide = mafia.theme.trside(target.role.side);
-                                    if (typeof inspectMode.seenSide == "string" && inspectMode.seenSide in mafia.theme.sideTranslations) {
-                                        revealedSide = mafia.theme.trside(inspectMode.seenSide);
-                                    }
-                                    gamemsg(player.name, target.name + " is sided with the " + revealedSide
-                                    + "!!", "Info");
-                                } else if (typeof Sight == "object") {
+                                var disguise = target.disguiseRole;
+                                var inspectedRole = target.role.role, inspectedSide = target.role.side;
+                                var inspectSide = Sight == "Team" || targetMode.revealSide !== undefined;
+                                
+                                if (typeof Sight == "object") {
                                     var srole = randomSample(Sight);
-                                    gamemsg(player.name, target.name + " is the " + mafia.theme.trrole((srole == "true") ? target.role.role : srole) + "!!", "Info");
+                                    if (srole != "true") {
+                                        if (disguise !== undefined) {
+                                            inspectedRole = disguise;
+                                        } else {
+                                            inspectedRole = srole;
+                                        }
+                                    }
+                                } else if (disguise !== undefined) {
+                                    inspectedRole = disguise;
                                 } else if (targetMode.revealAs !== undefined) {
                                     if (typeof targetMode.revealAs == "string") {
                                         if (targetMode.revealAs == "*") {
                                             var rrole = Object.keys(mafia.players).map(getPlayerRoleId, mafia);
-                                            gamemsg(player.name, target.name + " is the " + mafia.theme.trrole(rrole[Math.floor(Math.random() * rrole.length)]) + "!!", "Info");
+                                            inspectedRole = rrole[sys.rand(0, rrole.length)];
                                         } else {
-                                            gamemsg(player.name, target.name + " is the " + mafia.theme.trrole(targetMode.revealAs) + "!!", "Info");
+                                            inspectedRole = targetMode.revealAs;
                                         }
                                     } else if (Array.isArray(targetMode.revealAs)) {
-                                        gamemsg(player.name, target.name + " is the " + mafia.theme.trrole(targetMode.revealAs[Math.floor(Math.random() * targetMode.revealAs.length)]) + "!!", "Info");
+                                        inspectedRole = targetMode.revealAs[sys.rand(0, targetMode.revealAs.length)];
                                     }
+                                }
+                                
+                                if (typeof inspectMode.seenSide == "string") {
+                                    inspectedSide = inspectMode.seenSide;
+                                } else if (Sight == "Team" && disguise !== undefined) {
+                                    inspectedSide = mafia.theme.roles[disguise].side;
+                                }
+                                
+                                if (inspectSide) {
+                                    gamemsg(player.name, target.name + " is sided with the " + mafia.theme.trside(inspectedSide) + "!!", "Info");
                                 } else {
-                                    gamemsg(player.name, target.name + " is the " + target.role.translation + "!!", "Info");
+                                    gamemsg(player.name, target.name + " is the " + mafia.theme.trrole(inspectedRole) + "!!", "Info");
                                 }
                             }
                             else if (command == "kill") {
@@ -3473,12 +3543,12 @@ function Mafia(mafiachan) {
                                             gamemsgAll(formatArgs(allmsg, nightargs));
                                         }
                                         if (target !== player) {
-                                            pmsg = ("usermsg" in Action ? Action.usermsg : "Your target (~Target~) has been converted and is now a ~New~!").replace(/~Old~/g, oldRole.translation).replace(/~New~/g, target.role.translation);
+                                            pmsg = ("convertusermsg" in Action ? Action.convertusermsg : ("usermsg" in Action ? Action.usermsg : "Your target (~Target~) has been converted and is now a ~New~!")).replace(/~Old~/g, oldRole.translation).replace(/~New~/g, target.role.translation);
                                             gamemsg(player.name, formatArgs(pmsg, nightargs));
                                         }
                                         if (!Action.silentConvert) {
-                                            tarmsg = ("tarmsg" in Action ? Action.tarmsg : "You have been converted and changed roles!");
-                                            gamemsg(target.name, tarmsg);
+                                            tarmsg = ("tarmsg" in Action ? Action.tarmsg : "You have been converted and changed roles!").replace(/~Old~/g, oldRole.translation).replace(/~New~/g, target.role.translation);
+                                            gamemsg(target.name, formatArgs(tarmsg, nightargs));
                                             if (mafia.theme.delayedConversionMsg) {
                                                 mafia.needsConvertMsg.push(target.name);
                                             } else {
@@ -3518,8 +3588,8 @@ function Mafia(mafiachan) {
                                             gamemsgAll(formatArgs(allmsg, nightargs));
                                         }
                                         if (!Action.silentCopy) {
-                                            pmsg = ("usermsg" in Action ? Action.usermsg : "You copied someone and changed roles!");
-                                            gamemsg(player.name, pmsg);
+                                            pmsg = ("copyusermsg" in Action ? Action.copyusermsg : ("usermsg" in Action ? Action.usermsg : "You copied someone and changed roles!")).replace(/~Old~/g, oldRole.translation).replace(/~New~/g, player.role.translation);
+                                            gamemsg(player.name, formatArgs(pmsg, nightargs));
                                             if (mafia.theme.delayedConversionMsg) {
                                                 mafia.needsConvertMsg.push(player.name);
                                             } else {
@@ -3648,6 +3718,33 @@ function Mafia(mafiachan) {
                                     gamemsgAll(Action.singlemassconvertmsg.replace(/~Self~/g, player.name).replace(/~Target~/g, readable(singleAffected, "and")).replace(/~Number~/g, singleAffected.length)); //No args here to prevent conflicting replacements
                                 }
                             }
+                            else if (command == "disguise") {
+                                if (typeof Action.disguiseRole == "string") {
+                                    target.disguiseRole = Action.disguiseRole;
+                                } else if (typeof Action.disguiseRole == "object") {
+                                    if ("random" in Action.disguiseRole && !Array.isArray(Action.disguiseRole.random) && typeof Action.disguiseRole.random === "object" && Action.disguiseRole.random !== null) {
+                                        target.disguiseRole = randomSample(Action.disguiseRole.random);
+                                    } else {
+                                        var foundDisguise = false;
+                                        var possibleRoles = shuffle(Object.keys(Action.disguiseRole));
+                                        for (var nr in possibleRoles) {
+                                            if (possibleRoles[nr] != "auto" && Action.disguiseRole[possibleRoles[nr]].indexOf(target.role.role) != -1) {
+                                                target.disguiseRole = possibleRoles[nr];
+                                                foundDisguise = true;
+                                                break;
+                                            }
+                                        }
+                                        if (!foundDisguise) {
+                                            target.disguiseRole = Action.disguiseRole.auto;
+                                        }
+                                    }
+                                }
+                                    
+                                target.disguised = 1;
+                                target.disguiseCount = Action.disguiseCount || 1;
+                                var disguisemsg = ("disguisemsg" in Action ? Action.disguisemsg : "You disguised your target (~Target~) as ~Disguise~!").replace(/~Disguise~/g, mafia.theme.trrole(target.disguiseRole));
+                                gamemsg(player.name, formatArgs(disguisemsg, nightargs));
+                            }
     
                             //Post-Action effects here
                             if (revenge) {
@@ -3714,6 +3811,13 @@ function Mafia(mafiachan) {
                         gamemsg(player.name, (player.poisonDeadMessage ? player.poisonDeadMessage : "You died because of poison!"));
                         mafia.kill(player);
                         nightkill = true; // kinda night kill
+                    }
+                }
+                if (player.disguiseRole !== undefined) {
+                    if (player.disguised < player.disguiseCount) {
+                        player.disguised++;
+                    } else if (player.disguised >= player.disguiseCount) {
+                        player.disguiseRole = undefined;
                     }
                 }
             }
@@ -3950,11 +4054,23 @@ function Mafia(mafiachan) {
 
             if (tie) {
                 currentStalk.push("Lynched: No one");
-                if (mafia.theme.noplur === true) {
-                    gamemsgAll("A majority vote was not reached so no one was voted off!:");
-                } else {
-                    gamemsgAll("No one was voted off!:");
+                var votetiemsg = maxi > 0 ? mafia.theme.tiedvotemsg : mafia.theme.novotemsg;
+                var tiedPlayers = [];
+                if (maxi > 0) {
+                    for (x in voted) {
+                        if (voted[x] == maxi) {
+                            tiedPlayers.push(x);
+                        }
+                    }
                 }
+                
+                if (mafia.theme.noplur === true) {
+                    votetiemsg = votetiemsg.replace(/~Players~/g, readable(tiedPlayers, "and")).replace(/~Count~/g, maxi) || "A majority vote was not reached so no one was voted off!:";
+                } else {
+                    votetiemsg = votetiemsg.replace(/~Players~/g, readable(tiedPlayers, "and")).replace(/~Count~/g, maxi) || "No one was voted off!:";
+                }
+                gamemsgAll(votetiemsg);
+                
                 mafia.collectedSlay();
                 if (mafia.testWin()) {
                     return;
@@ -4546,7 +4662,7 @@ function Mafia(mafiachan) {
             return;
         }
         var inputmsg = "inputmsg" in player.role.actions.night[command] ? player.role.actions.night[command].inputmsg : "You have chosen to ~Action~ ~Target~!";
-        gamemsg(name, inputmsg.replace(/~Action~/g, command).replace(/~Target~/g, commandData));
+        gamemsg(name, inputmsg.replace(/~Action~/g, command).replace(/~Self~/g, name).replace(/~Target~/g, commandData));
         
         this.setTarget(player, target, command);
         var team;
@@ -4581,6 +4697,15 @@ function Mafia(mafiachan) {
         if ("avoidHax" in player.role.actions && player.role.actions.avoidHax.indexOf(command) != -1) {
             return;
         }
+        
+        if (!(command in player.haxCount)) {
+            player.haxCount[command] = 0;
+        }
+        player.haxCount[command] += 1;
+        if ("maxHax" in player.role.actions.night[command] && player.haxCount[command] > player.role.actions.night[command].maxHax) {
+            return;
+        }
+        
         var haxMultiplier = player.role.actions.night[command].haxMultiplier || 1;
         var haxRoles = mafia.theme.getHaxRolesFor(command);
         var haxers = [], haxTypes;
@@ -4630,6 +4755,7 @@ function Mafia(mafiachan) {
                 }
             }
         }
+        
         if (haxers.length > 0) {
             this.addPhaseStalkHax(name, command, target.name, haxers);
         }
@@ -4809,12 +4935,19 @@ function Mafia(mafiachan) {
                     command = commandObject.command;
 
                 if (target !== null) {
-                    if ((commandObject.target === undefined || ["Self", "Any"].indexOf(commandObject.target) == -1) && player == target) {
+                    if ((commandObject.target === undefined || ["Self", "Any", "OnlySelf", "OnlyTeam"].indexOf(commandObject.target) == -1) && player == target) {
                         gamemsg(srcname, "Nope, this wont work... You can't target yourself!", "Hint");
                         return;
                     } else if (commandObject.target == 'AnyButTeam' && player.role.side == target.role.side
                         || commandObject.target == 'AnyButRole' && player.role.role == target.role.role) {
                         gamemsg(srcname, "Nope, this wont work... You can't target your partners!", "Hint");
+                        return;
+                    } else if (commandObject.target == "OnlySelf" && target != player) {
+                        gamemsg(srcname, "You can only use this action on yourself!", "Hint");
+                        return;
+                    } else if ((commandObject.target == "OnlyTeammates" && player == target)
+                     || (["OnlyTeam", "OnlyTeammates"].indexOf(commandObject.target) !== -1 && player.role.side != target.role.side)) {
+                        gamemsg(name, "You can only use this action on your teammates!", "Hint");
                         return;
                     }
                 }
@@ -4918,6 +5051,33 @@ function Mafia(mafiachan) {
                         }
                     }
                 };
+                var massConvert = function(player, Action) {
+                    var convertRoles = Action.convertRoles, nr, k, singleAffected = [], affected, newRole, targetPlayers, convertedPlayer, newRole;
+                    for (nr in convertRoles) {
+                        targetPlayers = mafia.getPlayersForRole(nr);
+                        newRole = convertRoles[nr];
+                        affected = [];
+                        for (k in targetPlayers) {
+                            affected.push(targetPlayers[k]);
+                            convertedPlayer = mafia.players[targetPlayers[k]];
+                            mafia.setPlayerRole(convertedPlayer, newRole);
+                            if (!Action.silentMassConvert) {
+                                mafia.showOwnRole(sys.id(targetPlayers[k]));
+                            }
+                        }
+                        if (affected.length > 0 && Action.silent !== true) {
+                            if ("singlemassconvertmsg" in Action) {
+                                singleAffected = singleAffected.concat(affected);
+                            } else {
+                                var actionMessage = ("massconvertmsg" in Action ? Action.massconvertmsg : "The ~Old~ became a ~New~!").replace(/~Self~/g, player.name).replace(/~Target~/g, readable(affected, "and")).replace(/~Old~/g, mafia.theme.trrole(nr)).replace(/~New~/g, mafia.theme.trrole(newRole)).replace(/~Number~/g, affected.length);
+                                gamemsgAll(actionMessage);
+                            }
+                        }
+                    }
+                    if (singleAffected.length > 0) {
+                        gamemsgAll(Action.singlemassconvertmsg.replace(/~Self~/g, player.name).replace(/~Target~/g, readable(singleAffected, "and")).replace(/~Number~/g, singleAffected.length));
+                    }
+                };
                 
                 
                 if (command == "kill") {
@@ -5015,6 +5175,9 @@ function Mafia(mafiachan) {
                         if ("newRole" in commandObject) {
                             convertTo(player, target, commandObject);
                         }
+                        if ("convertRoles" in commandObject) {
+                            massConvert(player, commandObject);
+                        }
                         if (sys.id('PolkaBot') !== undefined) {
                             sys.sendMessage(sys.id('PolkaBot'), "±Luxray: "+target.name+" DIED", mafiachan);
                         }
@@ -5029,6 +5192,9 @@ function Mafia(mafiachan) {
                         }
                         if ("newRole" in commandObject) {
                             convertTo(player, target, commandObject);
+                        }
+                        if ("convertRoles" in commandObject) {
+                            massConvert(player, commandObject);
                         }
                         
                         if (sys.id('PolkaBot') !== undefined) {
@@ -5061,6 +5227,9 @@ function Mafia(mafiachan) {
                     gamemsgAll(revealMessage);
                     if ("newRole" in commandObject) {
                         convertTo(player, player, commandObject);
+                    }
+                    if ("convertRoles" in commandObject) {
+                        massConvert(player, commandObject);
                     }
                     sendChanAll(border, mafiachan);
                     player.revealUse = player.revealUse + 1 || 1;
@@ -5167,14 +5336,15 @@ function Mafia(mafiachan) {
                         if (target.role.actions.expose == "die") {
                             var diemsg = (target.role.actions.exposediemsg || "~Self~ could not live with being exposed to everyone and killed themselves!").replace(/~Self~/g, target.name).replace(/~Target~/g, name).replace(/~Action~/g, commandName);
                             gamemsgAll(diemsg);
-                            
                             if ("copyAs" in commandObject) {
                                 copyAs(player, target, commandObject);
                             }
                             if ("newRole" in commandObject) {
                                 convertTo(player, target, commandObject);
                             }
-                            
+                            if ("convertRoles" in commandObject) {
+                                massConvert(player, commandObject);
+                            }
                             this.kill(mafia.players[commandData]);
                             if (sys.id('PolkaBot') !== undefined) {
                                 sys.sendMessage(sys.id('PolkaBot'), "±Luxray: "+commandData+" DIED", mafiachan);
@@ -5185,6 +5355,9 @@ function Mafia(mafiachan) {
                             }
                             if ("newRole" in commandObject) {
                                 convertTo(player, target, commandObject);
+                            }
+                            if ("convertRoles" in commandObject) {
+                                massConvert(player, commandObject);
                             }
                         }
                         player.exposeUse = player.exposeUse + 1 || 1;
@@ -5198,6 +5371,9 @@ function Mafia(mafiachan) {
                         }
                         if ("newRole" in commandObject) {
                             convertTo(player, target, commandObject);
+                        }
+                        if ("convertRoles" in commandObject) {
+                            massConvert(player, commandObject);
                         }
                         
                         if (sys.id('PolkaBot') !== undefined) {

--- a/scripts/mafiachecker.js
+++ b/scripts/mafiachecker.js
@@ -7,7 +7,7 @@ function mafiaChecker() {
         fatalErrors,
         noMinor,
         noFatal,
-        possibleNightActions = ["kill", "protect", "inspect", "distract", "poison", "safeguard", "stalk", "watch", "convert", "curse", "copy", "detox", "dispel", "shield", "guard", "massconvert", "dummy", "dummy2", "dummy3", "dummy4", "dummy5", "dummy6", "dummy7", "dummy8", "dummy9", "dummy10" ],
+        possibleNightActions = ["kill", "protect", "inspect", "distract", "poison", "safeguard", "stalk", "watch", "convert", "curse", "copy", "detox", "dispel", "shield", "guard", "massconvert", "disguise", "dummy", "dummy2", "dummy3", "dummy4", "dummy5", "dummy6", "dummy7", "dummy8", "dummy9", "dummy10" ],
         badCommands = ["me", "commands", "start", "votetheme", "starttheme", "help", "roles", "sides", "myrole", "mafiarules", "themes", "themeinfo", "changelog", "details", "priority", "flashme", "playedgames", "update", "join", "unjoin", "mafiaadmins", "mafiaban", "mafiaunban", "passma", "mafiaadmin", "mafiaadminoff", "mafiasadmin", "mafiasuperadmin", "mafiasadminoff", "mafiasuperadminoff", "push", "slay", "shove", "end", "readlog", "add", "remove", "disable", "enable", "updateafter", "importold", "mafiaban", "mafiaunban", "mafiabans", "detained", "detainlist", "ban", "mute", "kick", "k", "mas", "ck", "cmute", "admin", "op", "owner", "invite", "member", "deadmin", "deregister", "deop", "demember", "deadmin", "lt", "featured", "featuretheme", "featurelink", "featuretext", "forcefeature", "ctogglecaps", "ctoggleflood", "topic", "cauth", "register", "deinvite", "cmeon", "cmeoff", "csilence", "csilenceoff", "cunmute", "cmutes", "cbans", "inviteonly", "ctoggleswear", "enabletours", "disabletours", "tempban", "say", "pokemon", "nature", "natures", "item", "ability", "notice", "featuredtheme"];
     
     this.checkTheme = function(raw) {
@@ -42,7 +42,7 @@ function mafiaChecker() {
                 lists.push("roles"+i);
                 ++i;
             }
-            checkAttributes(raw, ["name", "sides", "roles", "roles1"], ["villageCantLoseRoles", "author", "summary", "border", "killmsg", "killusermsg", "votemsg", "lynchmsg", "drawmsg", "minplayers", "noplur", "nolynch", "votesniping", "checkNoVoters", "quickOnDeadRoles", "ticks", "silentVote", "delayedConversionMsg", "nonPeak", "changelog", "changelog2", "threadlink", "altname", "tips", "closedSetup", "variables", "spawnPacks"].concat(lists), "Your theme");
+            checkAttributes(raw, ["name", "sides", "roles", "roles1"], ["villageCantLoseRoles", "author", "summary", "border", "killmsg", "killusermsg", "votemsg", "lynchmsg", "tiedvotemsg", "novotemsg", "drawmsg", "minplayers", "noplur", "nolynch", "votesniping", "checkNoVoters", "quickOnDeadRoles", "ticks", "silentVote", "delayedConversionMsg", "nonPeak", "changelog", "changelog2", "threadlink", "altname", "tips", "closedSetup", "variables", "spawnPacks"].concat(lists), "Your theme");
 
             if (checkType(raw.name, ["string"], "'theme.name'")) {
                 if (raw.name[raw.name.length - 1] == " ") {
@@ -72,6 +72,8 @@ function mafiaChecker() {
             checkType(raw.killusermsg, ["string"], "'theme.killusermsg'");
             checkType(raw.votemsg, ["string"], "'theme.votemsg'");
             checkType(raw.lynchmsg, ["string"], "'theme.lynchmsg'");
+            checkType(raw.tiedvotemsg, ["string"], "'theme.tiedvotemsg'");
+            checkType(raw.novotemsg, ["string"], "'theme.novotemsg'");
             checkType(raw.drawmsg, ["string"], "'theme.drawmsg'");
             checkType(raw.minplayers, ["number"], "'theme.minplayers'");
             checkType(raw.threadlink, ["string"], "'theme.threadlink'");
@@ -311,7 +313,7 @@ function mafiaChecker() {
                         if (checkType(action, ["object"], comm)) {
                             command = e;
                             commonMandatory = ["target", "common", "priority"];
-                            commonOptional = ["broadcast", "command", "limit", "msg", "failChance", "charges", "recharge", "initialrecharge", "broadcastmsg", "inputmsg", "chargesmsg", "clearCharges", "addCharges", "suicideChance", "suicidemsg", "restrict", "cancel", "ignoreDistract", "compulsory", "noRepeat", "pierce", "pierceChance", "noFollow", "haxMultiplier", "userMustBeVisited", "targetMustBeVisited", "userMustVisit", "targetMustVisit", "bypass", "hide"];
+                            commonOptional = ["broadcast", "command", "limit", "msg", "failChance", "charges", "recharge", "initialrecharge", "broadcastmsg", "inputmsg", "chargesmsg", "clearCharges", "addCharges", "suicideChance", "suicidemsg", "restrict", "cancel", "ignoreDistract", "compulsory", "noRepeat", "pierce", "pierceChance", "noFollow", "haxMultiplier", "maxHax", "userMustBeVisited", "targetMustBeVisited", "userMustVisit", "targetMustVisit", "bypass", "hide"];
                             commandList = [];
                             if ("command" in action) {
                                 if (Array.isArray(action.command)) {
@@ -346,7 +348,7 @@ function mafiaChecker() {
                             }
                             if (commandList.indexOf("convert") !== -1) {
                                 commonMandatory = commonMandatory.concat(["newRole"]);
-                                commonOptional = commonOptional.concat(["canConvert", "convertmsg", "usermsg", "tarmsg", "convertfailmsg", "silent", "silentConvert", "unlimitedSelfConvert"]);
+                                commonOptional = commonOptional.concat(["canConvert", "convertmsg", "usermsg", "convertusermsg", "tarmsg", "convertfailmsg", "silent", "silentConvert", "unlimitedSelfConvert"]);
                             }
                             if (commandList.indexOf("massconvert") !== -1) {
                                 commonMandatory = commonMandatory.concat(["convertRoles"]);
@@ -354,7 +356,7 @@ function mafiaChecker() {
                             }
                             if (commandList.indexOf("copy") !== -1) {
                                 commonMandatory = commonMandatory.concat(["copyAs"]);
-                                commonOptional = commonOptional.concat(["canCopy", "copymsg", "copyfailmsg", "usermsg", "silent", "silentCopy"]);
+                                commonOptional = commonOptional.concat(["canCopy", "copymsg", "copyfailmsg", "usermsg", "copyusermsg", "silent", "silentCopy"]);
                             }
                             if (commandList.indexOf("curse") !== -1) {
                                 commonMandatory = commonMandatory.concat(["cursedRole"]);
@@ -373,35 +375,39 @@ function mafiaChecker() {
                                 commonMandatory = commonMandatory.concat(["guardActions"]);
                                 commonOptional = commonOptional.concat(["guardmsg"]);
                             }
+                            if (commandList.indexOf("disguise") !== -1) {
+                                commonMandatory = commonMandatory.concat(["disguiseRole"]);
+                                commonOptional = commonOptional.concat(["disguisemsg", "disguiseCount"]);
+                            }
                             if (commandList.indexOf("dummy") !== -1) {
-                                commonOptional = commonOptional.concat(["dummyusermsg", "dummytargetmsg", "dummybroadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummyusermsg", "dummytargetmsg", "dummybroadcastmsg", "dummyPierce"]);
                             }
                             if (commandList.indexOf("dummy2") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy2usermsg", "dummy2targetmsg", "dummy2broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy2usermsg", "dummy2targetmsg", "dummy2broadcastmsg", "dummy2Pierce"]);
                             }
                             if (commandList.indexOf("dummy3") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy3usermsg", "dummy3targetmsg", "dummy3broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy3usermsg", "dummy3targetmsg", "dummy3broadcastmsg", "dummy3Pierce"]);
                             }
                             if (commandList.indexOf("dummy4") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy4usermsg", "dummy4targetmsg", "dummy4broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy4usermsg", "dummy4targetmsg", "dummy4broadcastmsg", "dummy4Pierce"]);
                             }
                             if (commandList.indexOf("dummy5") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy5usermsg", "dummy5targetmsg", "dummy5broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy5usermsg", "dummy5targetmsg", "dummy5broadcastmsg", "dummy5Pierce"]);
                             }
                             if (commandList.indexOf("dummy6") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy6usermsg", "dummy6targetmsg", "dummy6broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy6usermsg", "dummy6targetmsg", "dummy6broadcastmsg", "dummy6Pierce"]);
                             }
                             if (commandList.indexOf("dummy7") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy7usermsg", "dummy7targetmsg", "dummy7broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy7usermsg", "dummy7targetmsg", "dummy7broadcastmsg", "dummy7Pierce"]);
                             }
                             if (commandList.indexOf("dummy8") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy8usermsg", "dummy8targetmsg", "dummy8broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy8usermsg", "dummy8targetmsg", "dummy8broadcastmsg", "dummy8Pierce"]);
                             }
                             if (commandList.indexOf("dummy9") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy9usermsg", "dummy9targetmsg", "dummy9broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy9usermsg", "dummy9targetmsg", "dummy9broadcastmsg", "dummy9Pierce"]);
                             }
                             if (commandList.indexOf("dummy10") !== -1) {
-                                commonOptional = commonOptional.concat(["dummy10usermsg", "dummy10targetmsg", "dummy10broadcastmsg"]);
+                                commonOptional = commonOptional.concat(["dummy10usermsg", "dummy10targetmsg", "dummy10broadcastmsg", "dummy10Pierce"]);
                             }
                             
 
@@ -482,6 +488,7 @@ function mafiaChecker() {
                                     }
                                     checkType(action.convertmsg, ["string"], comm + ".convertmsg");
                                     checkType(action.usermsg, ["string"], comm + ".usermsg");
+                                    checkType(action.convertusermsg, ["string"], comm + ".convertusermsg");
                                     checkType(action.tarmsg, ["string"], comm + ".tarmsg");
                                     checkType(action.convertfailmsg, ["string"], comm + ".convertfailmsg");
                                 } else if (command == "massconvert") {
@@ -528,6 +535,7 @@ function mafiaChecker() {
                                     checkType(action.copymsg, ["string"], comm + ".copymsg");
                                     checkType(action.copyfailmsg, ["string"], comm + ".copyfailmsg");
                                     checkType(action.usermsg, ["string"], comm + ".usermsg");
+                                    checkType(action.copyusermsg, ["string"], comm + ".copyusermsg");
                                 } else if (command == "curse") {
                                     checkValidValue(action.silent, [true, false], comm + ".silent");
                                     checkValidValue(action.silentCurse, [true, false], comm + ".silentCurse");
@@ -579,17 +587,46 @@ function mafiaChecker() {
                                 } else if (command == "guard") {
                                     checkType(action.guardActions, ["array"], comm + ".guardActions");
                                     checkType(action.guardmsg, ["string"], comm + ".guardmsg");
-                                } else if (command == "dummy" || command == "dummy2" || command == "dummy3") {
+                                } else if (command == "disguise") {
+                                    if (checkType(action.disguiseRole, ["string", "object"], comm + ".disguiseRole")) {
+                                        if (typeof action.disguiseRole == "string") {
+                                            checkValidRole(action.disguiseRole, comm + ".disguiseRole");
+                                        } else {
+                                            if ("random" in action.disguiseRole && typeof action.disguiseRole.random == "object") {
+                                                for (i in action.disguiseRole.random) {
+                                                    checkValidRole(i, comm + ".disguiseRole.random");
+                                                    checkType(action.disguiseRole.random[i], ["number"], comm + ".disguiseRole.random." + i);
+                                                }
+                                            } else {
+                                                for (i in action.disguiseRole) {
+                                                    if (i == "auto") {
+                                                        checkValidRole(action.disguiseRole.auto, comm + ".disguiseRole.auto");
+                                                    } else {
+                                                        checkValidRole(i, comm + ".disguiseRole");
+                                                        if (checkType(action.disguiseRole[i], ["array"], comm + ".disguiseRole." + i)) {
+                                                            for (o in action.disguiseRole[i]) {
+                                                                checkValidRole(action.disguiseRole[i][o], comm + ".disguiseRole." + i);
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    checkType(action.disguiseCount, ["number"], comm + ".disguiseCount");
+                                    checkType(action.disguisemsg, ["string"], comm + ".disguisemsg");
+                                } else if (command == "dummy" || command == "dummy2" || command == "dummy3" || command == "dummy4" || command == "dummy5" || command == "dummy6" || command == "dummy7" || command == "dummy8" || command == "dummy9" || command == "dummy10") {
                                     checkType(action[command + "usermsg"], ["string"], comm + "." + command + "usermsg");
                                     checkType(action[command + "targetmsg"], ["string"], comm + "." + command + "targetmsg");
                                     checkType(action[command + "broadcastmsg"], ["string"], comm + "." + command + "broadcastmsg");
+                                    checkType(action[command + "Pierce"], ["boolean"], comm + "." + command + "Pierce");
                                 }
                             }
                         }
                     }
                 }
                 if (checkType(role.actions.standby, ["object"], act + ".standby")) {
-                    var appendActions = ["newRole", "canConvert", "silent", "convertmsg", "convertusermsg", "tarmsg", "copyAs", "canCopy", "copymsg", "copyusermsg"];
+                    var appendActions = ["newRole", "canConvert", "silent", "convertmsg", "convertusermsg", "tarmsg", "copyAs", "canCopy", "copymsg", "copyusermsg", "convertRoles", "singlemassconvertmsg", "massconvertmsg" ];
                     for (e in role.actions.standby) {
                         action = role.actions.standby[e];
                         comm = act + ".standby." + e;
@@ -602,7 +639,7 @@ function mafiaChecker() {
                             if (command == "kill") {
                                 checkAttributes(action, ["target", "killmsg"], ["command", "limit", "msg", "revealChance", "revealmsg", "recharge", "initialrecharge", "charges", "chargesmsg", "clearCharges", "addCharges"].concat(appendActions), comm);
                                 
-                                checkValidValue(action.target, ["Any", "Self", "AnyButTeam", "AnyButRole", "AnyButSelf"], comm + ".target");
+                                checkValidValue(action.target, ["Any", "Self", "AnyButTeam", "AnyButRole", "AnyButSelf", "OnlySelf", "OnlyTeam", "OnlyTeammates"], comm + ".target");
                                 checkType(action.limit, ["number"], comm + ".limit");
                                 checkType(action.msg, ["string"], comm + ".msg");
                                 checkType(action.killmsg, ["string"], comm + ".killmsg");
@@ -714,6 +751,19 @@ function mafiaChecker() {
                                 checkValidValue(action.silentCopy, [true, false], comm + ".silentCopy");
                                 checkType(action.copymsg, ["string"], comm + ".copymsg");
                                 checkType(action.copyusermsg, ["string"], comm + ".copyusermsg");
+                            }
+                            if ("convertRoles" in action) {
+                                if (checkType(action.convertRoles, ["object"], comm + ".convertRoles")) {
+                                    for (i in action.convertRoles) {
+                                        checkValidRole(i, comm + ".convertRoles");
+                                        checkValidRole(action.convertRoles[i], comm + ".convertRoles." + i);
+                                    }
+                                }
+                                
+                                checkType(action.massconvertmsg, ["string"], comm + ".massconvertmsg");
+                                checkType(action.singlemassconvertmsg, ["string"], comm + ".singlemassconvertmsg");
+                                checkType(action.silentMassConvert, ["boolean"], comm + ".silentMassConvert");
+                                checkType(action.silent, ["boolean"], comm + ".silent");
                             }
                         }
                     }
@@ -1495,6 +1545,7 @@ function mafiaChecker() {
         checkType(action.noRepeat, ["boolean"], act + ".noRepeat");
         checkType(action.pierce, ["boolean"], act + ".pierce");
         checkType(action.pierceChance, ["number"], act + ".pierceChance");
+        checkType(action.maxHax, ["number"], act + ".maxHax");
         checkType(action.haxMultiplier, ["number"], act + ".haxMultiplier");
         checkType(action.compulsory, ["boolean"], act + ".compulsory");
         checkType(action.noFollow, ["boolean"], act + ".noFollow");

--- a/scripts/mafiachecker.js
+++ b/scripts/mafiachecker.js
@@ -598,6 +598,9 @@ function mafiaChecker() {
                                                     checkType(action.disguiseRole.random[i], ["number"], comm + ".disguiseRole.random." + i);
                                                 }
                                             } else {
+                                                if (!("auto" in action.disguiseRole)) {
+                                                    addFatalError(comm + ".disguiseRole must have a property named 'auto'.");
+                                                }
                                                 for (i in action.disguiseRole) {
                                                     if (i == "auto") {
                                                         checkValidRole(action.disguiseRole.auto, comm + ".disguiseRole.auto");


### PR DESCRIPTION
-Night command: Disguise (makes target inspect as another role for X nights).
-maxHax: Limits number of command inputs that can be haxed by spies.
-More messages: copyusermsg (replaces usermsg for copy), convertusermsg (replaces usermsg for convert), tiedvotemsg and novotemsg (customize the "No one was voted off" message).
-Dummy Pierce: Pierce specific for dummy commands
-Standby Actions: Mass Convert effect, target as OnlySelf, OnlyTeam and OnlyTeammates
-Fix: Compulsory Actions will be used more times if action has "limit"
-5 seconds cooldown for /votetheme to avoid spam