### PR TITLE
Added a duplicate prevention to /addtouralert

### DIFF
--- a/scripts/usercommands.js
+++ b/scripts/usercommands.js
@@ -510,11 +510,9 @@ exports.handleCommand = function(src, command, commandData, tar, channel) {
         if (typeof SESSION.users(src).tiers == "string") {
             SESSION.users(src).tiers = SESSION.users(src).tiers.split("*");
         }
-        for (var x = 0; x < SESSION.users(src).tiers.length; x++) { // PREVENT DUPLICATE TOUR ALERTS
-            if (tier === SESSION.users(src).tiers[x]) {
-                normalbot.sendMessage(src, "The " + tier + " tier has already been added to your list of tour alerts!", channel);
-                return;
-            }
+        if (SESSION.users(src).tiers.indexOf(tier) !== -1) { // PREVENT DUPLICATE TOUR ALERTS
+            normalbot.sendMessage(src, "The " + tier + " tier has already been added to your list of tour alerts!", channel);
+            return;
         }
         SESSION.users(src).tiers.push(tier);
         script.saveKey("touralerts", src, SESSION.users(src).tiers.join("*"));

--- a/scripts/usercommands.js
+++ b/scripts/usercommands.js
@@ -510,6 +510,12 @@ exports.handleCommand = function(src, command, commandData, tar, channel) {
         if (typeof SESSION.users(src).tiers == "string") {
             SESSION.users(src).tiers = SESSION.users(src).tiers.split("*");
         }
+        for (var x = 0; x < SESSION.users(src).tiers.length; x++) { // PREVENT DUPLICATE TOUR ALERTS
+            if (tier === SESSION.users(src).tiers[x]) {
+                normalbot.sendMessage(src, "The " + tier + " tier has already been added to your list of tour alerts!", channel);
+                return;
+            }
+        }
         SESSION.users(src).tiers.push(tier);
         script.saveKey("touralerts", src, SESSION.users(src).tiers.join("*"));
         normalbot.sendMessage(src, "Added a tour alert for the tier: " + tier + "!", channel);


### PR DESCRIPTION
Before I could do "/addtouralert metronome", for example, multiple times.

Current:
(21:59:11) ±Dratini: You currently have no alerts activated
(21:59:20) ±Dratini: Added a tour alert for the tier: Metronome!
(21:59:21) ±Dratini: Added a tour alert for the tier: Metronome!
(21:59:25) ±Dratini: You currently get alerted for the tiers:
(21:59:25) ±Dratini: Metronome
(21:59:25) ±Dratini: Metronome

Update:
(22:00:09) ±Dratini: You currently have no alerts activated
(22:00:17) ±Dratini: Added a tour alert for the tier: Metronome!
(22:00:19) ±Dratini: The Metronome tier has already been added to your list of tour alerts!
(22:01:10) ±Dratini: You currently get alerted for the tiers:
(22:01:10) ±Dratini: Metronome