### PR TITLE
Added alert when queue is low or empty in VR

### DIFF
--- a/scripts/tours.js
+++ b/scripts/tours.js
@@ -3589,6 +3589,12 @@ function advanceround(key) {
 
 // starts a tournament
 function tourstart(tier, starter, key, parameters) {
+    if (tours.queue.length === 1) { // NOTIFY VICTORY ROAD THAT /QUEUE IS LOW
+        sys.sendAll(tourconfig.tourbot + "Queue in Tournaments is low.", sys.channelId("Victory Road"));
+    }
+    else if (tours.queue.length === 0) { // NOTIFY VICTORY ROAD THAT /QUEUE IS EMPTY
+        sys.sendAll(tourconfig.tourbot + "Queue in Tournaments is empty.", sys.channelId("Victory Road"));
+    }
     try {
         var channels = tourschan === 0 ? [0] : [0, tourschan];
         var now = new Date();


### PR DESCRIPTION
(03:42:56) ±Typhlosion: Queue in Tournaments is low. <-- when there is 1 tour in queue
(03:43:15) ±Typhlosion: Queue in Tournaments is empty. <-- when there are no tours in queue
They alert each time when a tour starts.