### PR TITLE
Delayed /catch when a wild appears, fix Luxury Ball, Bouncing Rocks and minor stuff

### DIFF
--- a/scripts/safari.js
+++ b/scripts/safari.js
@@ -218,7 +218,7 @@ function Safari() {
     
         //Other Items
         bait: {name: "bait", type: "usable", price: 100, successRate: 0.45, aliases:["bait"]},
-        rock: {name: "rock", type: "usable", price: 50, successRate: 0.75, aliases:["rock", "rocks"]},
+        rock: {name: "rock", type: "usable", price: 50, successRate: 0.75, bounceRate: 0.02, aliases:["rock", "rocks"]},
         gacha: {name: "gacha", type: "usable", price: 149, aliases:["gacha", "gachapon", "gachapon ticket", "gachaponticket"]}
     };
         
@@ -556,8 +556,8 @@ function Safari() {
             player.pokemon.push(currentPokemon);
             
             if (ball == "luxury") {
-                safaribot.sendAll(sys.name(src) + " also found $" + wildStats/2 + " on the ground after catching " + pokeName + "!" , safchan);
-                player.money += wildStats/2;
+                safaribot.sendAll(sys.name(src) + " also found $" + Math.floor(wildStats/2) + " on the ground after catching " + pokeName + "!" , safchan);
+                player.money += Math.floor(wildStats/2);
             }
             
             sys.sendAll("", safchan);
@@ -941,11 +941,15 @@ function Safari() {
         
         player.balls[item] -= 1;
         var rng = Math.random();
+        var targetName = utilities.non_flashing(sys.name(targetId));
         if (rng < itemData.rock.successRate) {
-            safaribot.sendAll(sys.name(src) + " threw a rock at " + sys.name(targetId) + "! *THUD* A direct hit! " + sys.name(targetId) + " was stunned!", safchan);
-            target.cooldown += 6000;
+            safaribot.sendAll(sys.name(src) + " threw a rock at " + targetName + "! *THUD* A direct hit! " + targetName + " was stunned!", safchan);
+            // target.cooldown = currentTime + 6000; //Remove comment to make rocks actually work
+        } else if (rng < itemData.rock.successRate + itemData.rock.bounceRate) {
+            safaribot.sendAll(sys.name(src) + " threw a rock at " + targetName + ", but it hit a wall and bounced back at " + sys.name(src) + "! *THUD* That will leave a mark on " + sys.name(src) + "'s face and pride!", safchan);
+            player.cooldown = currentTime + 8000;
         } else {
-            safaribot.sendAll(sys.name(src) + " threw a rock at " + sys.name(targetId) + "... but it missed!", safchan);
+            safaribot.sendAll(sys.name(src) + " threw a rock at " + targetName + "... but it missed!", safchan);
         }
         player.rockCooldown = currentTime + 10000;
     };
@@ -1457,6 +1461,9 @@ function Safari() {
             } else if (player.money > 9999999) {
                 player.money = 9999999;
             }
+            if (player.money % 1 !== 0) {
+                player.money = Math.floor(player.money);
+            }
             
             player.cooldown = now();
             player.gachaCooldown = now();
@@ -1521,7 +1528,10 @@ function Safari() {
             "Fast Ball: A weak but efficient Poké Ball that can be used in quick succession. Has a 0.5 second cooldown.",
             "Moon Ball: A stylized Poké Ball that supposedly works better against Pokémon seen once in a blue moon. Has an 8 second cooldown.",
             "Premier Ball: A plain Poké Ball gifted to you for your patronage. It works better when a Normal-type Pokémon is active. Has a 6 second cooldown.",
+            "",
+            "Note: Cooldown for Balls is doubled when a Pokémon is caught successfully.",
             ""
+            
         ];
         for (x in help) {
             sys.sendMessage(src, help[x], safchan);
@@ -1627,7 +1637,7 @@ function Safari() {
             return true;
         }
         if (command === "view") {
-            if (commandData) {
+            if (commandData !== "*") {
                 safari.viewPlayer(src, commandData);
             } else {
                 safari.viewOwnInfo(src, commandData);


### PR DESCRIPTION
-Added a 4~6 seconds period where all /catch inputs are registered and then executed with a random order at the end of this period.
-Fix Luxury Ball not rounding 0.5;
-Rocks now have a small chance of bouncing back at the thrower;
-Rock's message no longer flash the target;
-/view with no commandData works as /mydata;
-Added note to /itemhelp about ball's cooldown doubling.