### PR TITLE
/findsaves

### DIFF
--- a/scripts/safari.js
+++ b/scripts/safari.js
@@ -1827,6 +1827,10 @@ function Safari() {
             }
             return true;
         }
+        if (command === "findsaves") {
+            safaribot.sendMessage(src, "List of all saves by name: " + Object.keys(rawPlayers.hash).sort().join(", "), safchan);
+            return true;
+        }
                 
         if (!SESSION.channels(safchan).isChannelOwner(src)) {
             return false;


### PR DESCRIPTION
Gets a raw list of all safari save names to help people find in which alt they had their save. 
Will probably need a query/filter later.