### PR TITLE
Allow /cbans to search users, separate invite/invitespec delay

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -712,7 +712,7 @@ unban: function(type, src, tar, commandData) {
             banbot = normalbot;
         }
     var verb = {"mute": "unmuted", "mban": "unbanned from Mafia", "smute": "secretly unmuted", "hmute": "unbanned from Hangman", "safban": "unbanned from Safari"}[type];
-    var nomi = {"mute": "mute", "mban": "mafia ban", "smute": "secret mute", "hmute": "hangman ban", "safban": "safari ban"}[type];
+    var nomi = {"mute": "unmute", "mban": "mafia unban", "smute": "secret unmute", "hmute": "hangman unban", "safban": "safari unban"}[type];
     var past = {"mute": "muted", "mban": "mafia banned", "smute": "secretly muted", "hmute": "hangman banned", "safban": "safari banned"}[type];
     var sendAll =  {
         "smute": function(line) {

--- a/scripts/channelcommands.js
+++ b/scripts/channelcommands.js
@@ -318,8 +318,8 @@ exports.handleCommand = function (src, command, commandData, tar, channel) {
             return;
         }
         var now = (new Date()).getTime();
-        if (now < SESSION.users(src).inviteDelay) {
-            channelbot.sendMessage(src, "Please wait before sending another invite!");
+        if (typeof SESSION.users(tar).inviteDelay === "object" && SESSION.users(tar).inviteDelay.hasOwnProperty(sys.ip(src)) && now < SESSION.users(tar).inviteDelay[sys.ip(src)]) {
+            channelbot.sendMessage(src, "Please wait before sending another invite!", channel);
             return;
         }
         if (!sys.isInChannel(tar, channel)) {
@@ -331,7 +331,10 @@ exports.handleCommand = function (src, command, commandData, tar, channel) {
         } else {
             channelbot.sendMessage(src, "Your target was invited.", channel);
         }
-        SESSION.users(src).inviteDelay = (new Date()).getTime() + 8000;
+        if (typeof SESSION.users(tar).inviteDelay !== "object") {
+            SESSION.users(tar).inviteDelay = {};
+        }
+        SESSION.users(tar).inviteDelay[sys.ip(src)] = (new Date()).getTime() + 8000;
         return;
     }
     if (command === "member") {
@@ -420,18 +423,22 @@ exports.handleCommand = function (src, command, commandData, tar, channel) {
         return;
     }
     if (command === "cmutes") {
-        var cmuteList = poChannel.getReadableList("mutelist", sys.os(src));
-        if (cmuteList !== "") {
-            sys.sendHtmlMessage(src, cmuteList, channel);
+        var cmutelist = poChannel.getReadableList("mutelist", sys.os(src), commandData);
+        if (cmutelist !== "") {
+            sys.sendHtmlMessage(src, cmutelist, channel);
+        } else if (commandData !== undefined) {
+            channelbot.sendMessage(src, "No users muted in this channel have \"" + commandData +  "\" in their name.", channel);
         } else {
             channelbot.sendMessage(src, "No one is muted on this channel.", channel);
         }
         return;
     }
     if (command === "cbans") {
-        var cbanList = poChannel.getReadableList("banlist", sys.os(src));
-        if (cbanList !== "") {
-            sys.sendHtmlMessage(src, cbanList, channel);
+        var cbanlist = poChannel.getReadableList("banlist", sys.os(src), commandData);
+        if (cbanlist !== "") {
+            sys.sendHtmlMessage(src, cbanlist, channel);
+        } else if (commandData !== undefined) {
+            channelbot.sendMessage(src, "No users banned in this channel have \"" + commandData +  "\" in their name.", channel);
         } else {
             channelbot.sendMessage(src, "No one is banned on this channel.", channel);
         }
@@ -690,7 +697,7 @@ exports.help = function (src, channel) {
         sys.sendMessage(src, "/removerule [number]: Remove a rule [number].", channel);
         sys.sendMessage(src, "/editrule [number]:[name]:[description]: Edit rule [number].", channel);
     }
-    if (SESSION.global().permaTours.indexOf(channel) > -1) {
+    if (Array.isArray(SESSION.global().permaTours) && SESSION.global().permaTours.indexOf(channel) > -1) {
         sys.sendMessage(src, "*** Channel Tournaments commands ***", channel);
         sys.sendMessage(src, "/join: Enters you to in a tournament.", channel);
         sys.sendMessage(src, "/unjoin: Withdraws you from a tournament.", channel);

--- a/scripts/channelfunctions.js
+++ b/scripts/channelfunctions.js
@@ -598,7 +598,7 @@ POChannel.prototype.changeParameter = function(src, parameter, value) {
     }
 };
 
-POChannel.prototype.getReadableList = function (type, os) {
+POChannel.prototype.getReadableList = function (type, os, searchData) {
     try {
         var entries = {}, name = "";
         if (type == "mutelist") {
@@ -613,21 +613,24 @@ POChannel.prototype.getReadableList = function (type, os) {
         if (os === undefined) {
             os = "windows";
         }
-        var width = 4, maxMessageLength = 30000, tmp = [];
+        var width = 5, maxMessageLength = 30000, tmp = [];
         for (var x in entries) {
-            if (entries.hasOwnProperty(x)) {
-            if (!entries[x].hasOwnProperty("expiry")) {
-                continue;
-            }
-            var playername = utilities.html_escape(x);
-            var expirytime = isNaN(entries[x].expiry) ? "never" : entries[x].expiry-parseInt(sys.time(),10);
-            if (expirytime <= 0) {
-                continue;
-            }
-            var issuetime = getTimeString(parseInt(sys.time(),10)-entries[x].issuetime);
-            var auth = utilities.html_escape(entries[x].auth);
-            var reason = utilities.html_escape(entries[x].reason);
-            tmp.push([playername, auth, issuetime, isNaN(entries[x].expiry) ? expirytime : getTimeString(expirytime), reason]);
+                if (entries.hasOwnProperty(x)) {
+                if (!entries[x].hasOwnProperty("expiry")) {
+                    continue;
+                }
+                if (searchData !== undefined && x.toLowerCase().indexOf(searchData.toLowerCase()) === -1) {
+                    continue;
+                }
+                var playername = utilities.html_escape(x);
+                var expirytime = isNaN(entries[x].expiry) ? "never" : entries[x].expiry-parseInt(sys.time(),10);
+                if (expirytime <= 0) {
+                    continue;
+                }
+                var issuetime = getTimeString(parseInt(sys.time(),10)-entries[x].issuetime);
+                var auth = utilities.html_escape(entries[x].auth);
+                var reason = utilities.html_escape(entries[x].reason);
+                tmp.push([playername, auth, issuetime, isNaN(entries[x].expiry) ? expirytime : getTimeString(expirytime), reason]);
             }
         }
         tmp.sort(function(a,b) { return a[2] - b[2];});

--- a/scripts/usercommands.js
+++ b/scripts/usercommands.js
@@ -963,12 +963,16 @@ exports.handleCommand = function (src, command, commandData, tar, channel) {
             return;
         }*/
         var now = (new Date()).getTime();
-        if (now < SESSION.users(src).inviteDelay) {
-            normalbot.sendMessage(src, "Please wait before sending another invite!");
+        if (typeof SESSION.users(tar).inviteBattleDelay === "object" && SESSION.users(tar).inviteBattleDelay.hasOwnProperty(sys.ip(src)) && now < SESSION.users(tar).inviteBattleDelay[sys.ip(src)]) {
+            normalbot.sendMessage(src, "Please wait before sending another battle invite!", channel);
             return;
         }
-        sys.sendHtmlMessage(tar, "<font color='brown'><timestamp/><b>±Sentret:  </b></font><a href='po:watchplayer/" + sys.name(src) + "'><b>" + utilities.html_escape(sys.name(src)) + "</b> would like you to watch their battle!</a>");
-        SESSION.users(src).inviteDelay = (new Date()).getTime() + 10000;
+        normalbot.sendMessage(src, "You invited " + sys.name(tar) + " to watch your battle.", channel);
+        sys.sendHtmlMessage(tar, "<font color='brown'><timestamp/><b>±Sentret: </b></font><a href='po:watchplayer/" + sys.name(src) + "'><b>" + utilities.html_escape(sys.name(src)) + "</b> would like you to watch their battle!</a>");
+        if (typeof SESSION.users(tar).inviteBattleDelay !== "object") {
+            SESSION.users(tar).inviteBattleDelay = {};
+        }
+        SESSION.users(tar).inviteBattleDelay[sys.ip(src)] = (new Date()).getTime() + 10000;
         return;
     }
     if (command === "notice") {

--- a/scripts/userfunctions.js
+++ b/scripts/userfunctions.js
@@ -1,3 +1,5 @@
+/*global sys, script, callplugins, utilities, exports */
+
 function POUser(id)
 {
     /* user's id */
@@ -76,8 +78,7 @@ function POUser(id)
     /* check if user is banned or mafiabanned */
     var data;
     var loopArgs = [["mute", script.mutes], ["mban", script.mbans], ["smute", script.smutes], ["hmute", script.hmutes], ["safban", script.safbans]];
-    //If you add something, increase the i < x by 1
-    for (i = 0; i < 5; ++i) {
+    for (var i = 0; i < loopArgs.length; ++i) {
         var action = loopArgs[i][0];
         if ((data = loopArgs[i][1].get(sys.ip(id))) !== undefined) {
             this[action].active=true;

--- a/scripts/userfunctions.js
+++ b/scripts/userfunctions.js
@@ -45,7 +45,9 @@ function POUser(id)
     /* stopping spam */
     this.pmwarned = false;
     /* invite delay */
-    this.inviteDelay = 0;
+    this.inviteDelay = {};
+    /* invitespec delay */
+    this.inviteBattleDelay = {};
     /* tour alert */
     if (script.getKey('touralertson', id) == "true") {
         this.tiers = script.getKey("touralerts", id).split("*");


### PR DESCRIPTION
- Also fix /unmute telling you that you can't mute yourself (when you're
trying to unmute yourself)
- Also stop error when channel tours aren't in effect

Invite change:
- Before, you had to wait between every invite, even if it was to
different people
- This will still prevent a user from being invite spammed by the same
person

I was also thinking of allowing channel owners to cban other channel owners since they can deowner anyway and changing csilence to not use delayedCall and to be able to silence certain cauth levels (i.e. no cauth/members/op/admins) but idk if these are necessary/wanted.