### PR TITLE
Allow for rock to serve as $25 pawnable

### DIFF
--- a/scripts/safari.js
+++ b/scripts/safari.js
@@ -315,7 +315,7 @@ function Safari() {
 
         //Other Items
         //Seasonal change. Rock icon is 206, Snowball is 334
-        rock: {name: "rock", fullName: "Rock", type: "items", icon: 206, price: 50, successRate: 0.65, bounceRate: 0.1, targetCD: 7000, bounceCD: 11000, throwCD: 15000,  aliases:["rock", "rocks", "snow", "snowball", "snowballs"], tradable: false},
+        rock: {name: "rock", fullName: "Rock", type: "valuables", icon: 206, price: 50, successRate: 0.65, bounceRate: 0.1, targetCD: 7000, bounceCD: 11000, throwCD: 15000,  aliases:["rock", "rocks", "snow", "snowball", "snowballs"], tradable: true},
         bait: {name: "bait", fullName: "Bait", type: "items", icon: 8017, price: 129, successRate: 0.4, failCD: 13, successCD: 70, aliases:["bait"], tradable: false},
         golden: {name: "golden", fullName: "Golden Bait", type: "items", icon: 8016, price: 750, successRate: 0.75, failCD: 20, successCD: 30, minBstBonus: 10, bstBonus: 8, shinyBonus: 0, aliases:["goldenbait", "golden bait", "golden"], tradable: false},
         gacha: {name: "gacha", fullName: "Gachapon Ticket", type: "items", icon: 132, price: 218, cooldown: 9000, aliases:["gacha", "gachapon", "gachapon ticket", "gachaponticket"], tradable: false},
@@ -461,7 +461,7 @@ function Safari() {
         dust: "What you obtain after smashing a Rare Candy into powder. Has the power to evolve Pokémon. Use with \"/evolve [Pokémon]\".",
         spray: "A spray that affects the genetic code of a Pokémon, making them devolve and generating some Candy Dust. Use with \"/spray [Pokémon]\". Obtained from Prize Packs.",
         mega: "A mysterious stone that allows certain Pokémon to undergo a powerful transformation. It is said to wear off in approximately " + itemData.mega.duration + " days. Use with \"/mega [Pokémon]\". Obtained from Official Events and Prize Packs.",
-        valuables: "The items Pearl, Stardust, Big Pearl, Star Piece, Nugget and Big Nugget can be sold for a varying amount of money. Sell with \"/pawn [Item]\". Obtained from Gachapon, found with Itemfinder, and rewarded from Contests.",
+        valuables: "The items Rock, Pearl, Stardust, Big Pearl, Star Piece, Nugget and Big Nugget can be sold for a varying amount of money. Sell with \"/pawn [Item]\". Obtained from Gachapon, found with Itemfinder, and rewarded from Contests.",
         itemfinder: "Itemfinder: An experimental machine that can help find rare items! By default, it can only hold " + itemData.itemfinder.charges + " charges. These charges are reset every day. Use with \"/finder\".",
         gem: "An electrically charged gem created by a famous Ampharos in Olivine City. It is said to be able to recharge the Itemfinder, giving it " + itemData.gem.charges + " more uses for the day! Use with \"/use gem\". Obtained from Gachapon and quests.",
         box: "Increases number of Pokémon that can be owned by " + itemData.box.bonusRate + " each. Can only acquire by purchasing.",

--- a/scripts/safari.js
+++ b/scripts/safari.js
@@ -6321,13 +6321,7 @@ function Safari() {
 
         var pawning = [], item, amount, pawnAll;
         if (data.toLowerCase() === "all") {
-            var valuablesExcludingRock = [];
-            for (var e in validItems) {
-                if (itemData[e].price !== itemData.rock.price) {
-                    valuablesExcludingRock.push(itemData[e].name);
-                }
-            }
-            pawning = valuablesExcludingRock;
+            pawning = validItems;
             pawnAll = true;
         } else {
             var info = data.split(":");
@@ -6357,6 +6351,9 @@ function Safari() {
             item = pawning[i];
             if (player.balls[item] > 0) {
                 if (pawnAll) {
+                    if (item === "rock") {
+                        continue;
+                    }
                     amount = player.balls[item];
                 }
                 cost = Math.floor(amount * itemData[item].price/2 * perkBonus);

--- a/scripts/safari.js
+++ b/scripts/safari.js
@@ -6321,7 +6321,13 @@ function Safari() {
 
         var pawning = [], item, amount, pawnAll;
         if (data.toLowerCase() === "all") {
-            pawning = validItems;
+            var valuablesExcludingRock = [];
+            for (var e in validItems) {
+                if (itemData[e].price !== itemData[rock].price) {
+                    valuablesExcludingRock.push(itemData[e].name);
+                }
+            }
+            pawning = valuablesExcludingRock;
             pawnAll = true;
         } else {
             var info = data.split(":");
@@ -15097,7 +15103,7 @@ function Safari() {
             "/catch [ball]: To throw a Safari Ball when a wild Pokémon appears. [ball] can be replaced with the name of any other ball you possess.",
             "/sell: To sell one of your Pokémon.",
             "/exchange: To exchange one of your Pokémon for Raffle Entries!",
-            "/pawn: To sell specific items. Use /pawnall to sell all your pawnable items at once!",
+            "/pawn: To sell specific items. Use /pawnall to sell all your pawnable items at once, except rocks!",
             "/trade: To request a Pokémon trade with another player*. Use $200 to trade money and @luxury to trade items (use 3@luxury to trade more than 1 of that item).",
             "/buy: To buy items or Pokémon from an NPC.",
             "/shop: To buy items or Pokémon from a another player.",

--- a/scripts/safari.js
+++ b/scripts/safari.js
@@ -6323,7 +6323,7 @@ function Safari() {
         if (data.toLowerCase() === "all") {
             var valuablesExcludingRock = [];
             for (var e in validItems) {
-                if (itemData[e].price !== itemData[rock].price) {
+                if (itemData[e].price !== itemData.rock.price) {
                     valuablesExcludingRock.push(itemData[e].name);
                 }
             }


### PR DESCRIPTION
One aspect of the game that acts as a limiting factor on the overall kindness of the safari community is the excessive distribution of rocks.  Players are given extremely high numbers of rocks, considering gacha, itemfinder, login bonus, and contest prizes.  The only thing players can do with these is to rock other players — an almost derogatory action.  This would make since to be able to do for $50, and maybe given seldom, i.e. as a contest prize only, but the rate at which Safari gives them encourages this derogatory action.  Players should have an incentive to _build each other up not down_, so I reclassified rocks as pawnables that can be pawned for $25-$27 using /pawn rock:1, or traded: just like any other pawnable.  Please approve this edit to reduce Safari players' incentive to rock one another.