### PR TITLE
memoryhash

### DIFF
--- a/scripts/memoryhash.js
+++ b/scripts/memoryhash.js
@@ -44,7 +44,10 @@ MemoryHash.prototype.add = function(key, value)
 
 MemoryHash.prototype.get = function(key)
 {
-    return this.hash[key];
+    if (this.hash.hasOwnProperty(key)) {
+        return this.hash[key];
+    }
+    return undefined;
 }
 
 MemoryHash.prototype.remove = function(key)


### PR DESCRIPTION
accessing memoryhash's get without checking hasOwnProperty would result in prototype methods being returned, which i doubt is desirable anywhere this is used.