### PR TITLE
Convert warns to JSON

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -125,7 +125,7 @@ var cleanFile = function(filename) {
     if (typeof sys != 'undefined')
         sys.appendToFile(filename, "");
 };
-[Config.dataDir+"mafia_stats.json", Config.dataDir+"suspectvoting.json", Config.dataDir+"mafiathemes/metadata.json", Config.dataDir+"channelData.json", Config.dataDir+"mutes.txt", Config.dataDir+"mbans.txt", Config.dataDir+"mwarns.txt", Config.dataDir+"safbans.txt", Config.dataDir+"hmutes.txt", Config.dataDir+"smutes.txt", Config.dataDir+"rangebans.txt", Config.dataDir+"contributors.txt", Config.dataDir+"ipbans.txt", Config.dataDir+"namesToWatch.txt", Config.dataDir+"watchNamesLog.txt", Config.dataDir+"hangmanadmins.txt", Config.dataDir+"hangmansuperadmins.txt", Config.dataDir+"pastebin_user_key", Config.dataDir+"secretsmute.txt", Config.dataDir+"ipApi.txt", Config.dataDir + "notice.html", Config.dataDir + "rangewhitelist.txt", Config.dataDir + "idbans.txt", Config.dataDir+"league.json", Config.dataDir + "autoteamsauth.txt"].forEach(cleanFile);
+[Config.dataDir+"mafia_stats.json", Config.dataDir+"suspectvoting.json", Config.dataDir+"mafiathemes/metadata.json", Config.dataDir+"channelData.json", Config.dataDir+"mutes.txt", Config.dataDir+"mbans.txt", Config.dataDir+"mwarns.json", Config.dataDir+"safbans.txt", Config.dataDir+"hmutes.txt", Config.dataDir+"smutes.txt", Config.dataDir+"rangebans.txt", Config.dataDir+"contributors.txt", Config.dataDir+"ipbans.txt", Config.dataDir+"namesToWatch.txt", Config.dataDir+"watchNamesLog.txt", Config.dataDir+"hangmanadmins.txt", Config.dataDir+"hangmansuperadmins.txt", Config.dataDir+"pastebin_user_key", Config.dataDir+"secretsmute.txt", Config.dataDir+"ipApi.txt", Config.dataDir + "notice.html", Config.dataDir + "rangewhitelist.txt", Config.dataDir + "idbans.txt", Config.dataDir+"league.json", Config.dataDir + "autoteamsauth.txt"].forEach(cleanFile);
 
 var autosmute = sys.getFileContent(Config.dataDir+"secretsmute.txt").split(':::');
 var crc32 = require('crc32.js').crc32;
@@ -545,7 +545,6 @@ init : function() {
     /* restore mutes, smutes, mafiabans, mafiawarns, rangebans, megausers */
     script.mutes = new MemoryHash(Config.dataDir+"mutes.txt");
     script.mbans = new MemoryHash(Config.dataDir+"mbans.txt");
-    script.mwarns = new MemoryHash(Config.dataDir+"mwarns.txt");
     script.smutes = new MemoryHash(Config.dataDir+"smutes.txt");
     script.rangebans = new MemoryHash(Config.dataDir+"rangebans.txt");
     script.contributors = new MemoryHash(Config.dataDir+"contributors.txt");

--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -68,7 +68,7 @@ function Mafia(mafiachan) {
                     shove = warning.split(":::")[1].split("|||")[0],
                     info = JSON.parse(warning.split(":::")[1].split("|||")[1]);
                 newWarns[ip] = {
-                    names: [],
+                    names: [name],
                     shove: shove === "true" ? true : false,
                     warns: []
                 };


### PR DESCRIPTION
- Save event time over updates
- Prevent whisper spam

This makes it easier to track warns across a user's different IPs and do other stuff.