### PR TITLE
Fixed tie bug, event flag properly set

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -3348,6 +3348,7 @@ function Mafia(mafiachan) {
             if (checkDay < mafia.time.nights) {
                 pastDay = true;
             }
+            mafia.isEvent = false;
             gamemsg(sentName, "*** VOTECOUNT FOR DAY " + checkDay + " ***");
             voteData = this.votedByArchive[checkDay];
         }


### PR DESCRIPTION
Resolves the issue where events would continue if one ended as a tie. Should fix the problem that prevented shady coins from working properly.