### PR TITLE
Fixes isEvent not being set on tie

### DIFF
--- a/scripts/mafia.js
+++ b/scripts/mafia.js
@@ -3396,6 +3396,7 @@ function Mafia(mafiachan) {
             //mafiabot.sendAll("GAME ENDED", mafiachan);
             mafia.unloadAWOL();
             mafia.clearVariables();
+            mafia.isEvent = false;
             runUpdate();
             this.advertiseFeaturedTheme();
             return true;


### PR DESCRIPTION
Resolves the issue where the isEvent flag would not be reset if an event game ended as a tie. Should fix the problem that prevented shady coins from working properly.