### PR TITLE
Prevent Android from joining tours with wrong gen

### DIFF
--- a/scripts/tours.js
+++ b/scripts/tours.js
@@ -2453,6 +2453,15 @@ function tourCommand(src, command, commandData, channel) {
                     break;
                 }
             }
+            if (sys.os(src) === "android") {
+                var playerSubGen = sys.gen(src, 0) + "-" + sys.subgen(src, 0);
+                var tourGen = tours.tour[key].parameters.gen;
+                if (tourGen === "default") { tourGen = defaultgen; }
+                if (playerSubGen !== tourGen) {
+                    sendBotMessage(src, "Please make sure that the generation of your team <b>(" + getSubgen(playerSubGen, true) + ")</b> matches the generation of the tournament <b>(" + getSubgen(tourGen, true) + ")</b> before attempting to join. The generation can be changed in the teambuilder.", tourschan, true);
+                    return true;
+                }
+            }
             if (!sys.hasTier(src, b)) {
                 if (ccbfFound) {
                     sys.changeTier(src, 0, b);


### PR DESCRIPTION
Check for the "accepted challenge but battle didn't start" android bug that occurs when android users join tours with a different generation loaded but the script doesn't actually change their generation.